### PR TITLE
chore: storage get non-existent key will not raise error

### DIFF
--- a/python/dify_plugin/invocations/storage.py
+++ b/python/dify_plugin/invocations/storage.py
@@ -19,20 +19,23 @@ class StorageInvocation(BackwardsInvocation[dict]):
 
             raise Exception("unexpected data")
 
-        Exception("no data found")
-
-    def get(self, key: str) -> bytes:
-        for data in self._backwards_invoke(
-            InvokeType.Storage,
-            dict,
-            {
-                "opt": "get",
-                "key": key,
-            },
-        ):
-            return unhexlify(data["data"])
-
         raise Exception("no data found")
+
+    def get(self, key: str) -> bytes | None:
+        try:
+            for data in self._backwards_invoke(
+                InvokeType.Storage,
+                dict,
+                {
+                    "opt": "get",
+                    "key": key,
+                },
+            ):
+                return unhexlify(data["data"])
+        except Exception as e:
+            if "load data failed, please check if the key is correct" in str(e):
+                return None
+            raise 
 
     def delete(self, key: str) -> None:
         for data in self._backwards_invoke(


### PR DESCRIPTION
when we use `item.get(key)` method of a python dict  or redis,  it will not raise error.  

So I think the interface should keep consistency.

Then we can use 
```
if item:= self.session.storage.get(key):
    ...
```
instead of try...catch...