### PR TITLE
fix: UploadFileResponse to support optional type initialization from mime_type

### DIFF
--- a/python/dify_plugin/invocations/file.py
+++ b/python/dify_plugin/invocations/file.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Optional
 
 import requests
 from pydantic import BaseModel, model_validator

--- a/python/dify_plugin/invocations/file.py
+++ b/python/dify_plugin/invocations/file.py
@@ -1,4 +1,5 @@
 from enum import Enum
+from typing import Optional
 
 import requests
 from pydantic import BaseModel
@@ -30,7 +31,11 @@ class UploadFileResponse(BaseModel):
     size: int
     extension: str
     mime_type: str
-    type: Type
+    type: Optional[Type] = None
+
+    def __init__(self, **data):
+        data['type'] = self.Type.from_mime_type(data.get('mime_type', ''))
+        super().__init__(**data)
 
     def to_app_parameter(self) -> dict:
         return {

--- a/python/dify_plugin/invocations/file.py
+++ b/python/dify_plugin/invocations/file.py
@@ -2,7 +2,7 @@ from enum import Enum
 from typing import Optional
 
 import requests
-from pydantic import BaseModel
+from pydantic import BaseModel, model_validator
 
 from dify_plugin.core.entities.invocation import InvokeType
 from dify_plugin.core.runtime import BackwardsInvocation
@@ -31,11 +31,14 @@ class UploadFileResponse(BaseModel):
     size: int
     extension: str
     mime_type: str
-    type: Optional[Type] = None
+    type: Type
 
-    def __init__(self, **data):
-        data['type'] = self.Type.from_mime_type(data.get('mime_type', ''))
-        super().__init__(**data)
+    @model_validator(mode="before")
+    @classmethod
+    def validate_type(cls, d):
+        if "type" not in d:
+            d["type"] = cls.Type.from_mime_type(d.get("mime_type", ""))
+        return d
 
     def to_app_parameter(self) -> dict:
         return {


### PR DESCRIPTION
Fixed `UploadFileResponse` to be correctly initialized from `response` value.

https://github.com/langgenius/dify-plugin-sdks/blob/e764cd2d9e0225b9ac4f27d3e486ed0578b47a46/python/dify_plugin/invocations/file.py#L66-L70

