### PR TITLE
fix ParameterType.TEXT is not supported

### DIFF
--- a/python/dify_plugin/interfaces/model/large_language_model.py
+++ b/python/dify_plugin/interfaces/model/large_language_model.py
@@ -259,6 +259,9 @@ class LargeLanguageModel(AIModel):
                 # validate options
                 if parameter_rule.options and parameter_value not in parameter_rule.options:
                     raise ValueError(f"Model Parameter {parameter_name} should be one of {parameter_rule.options}.")
+            elif parameter_rule.type == ParameterType.TEXT:
+                if not isinstance(parameter_value, str):
+                    raise ValueError(f"Model Parameter {parameter_name} should be string.")
             else:
                 raise ValueError(f"Model Parameter {parameter_name} type {parameter_rule.type} is not supported.")
 


### PR DESCRIPTION
ParameterType.TEXT is used for `json_schema` field.  

Now use this feature will raise error:
![image](https://github.com/user-attachments/assets/0e32f406-5d1d-473b-be1a-0e399f636541)


0.15 repo's [code](https://github.com/langgenius/dify/blob/989fb11fd715a96576333207189a12d8594c60f1/api/core/model_runtime/model_providers/__base/large_language_model.py#L866)
