### PR TITLE
label display error when use_template

### DIFF
--- a/python/dify_plugin/entities/model/__init__.py
+++ b/python/dify_plugin/entities/model/__init__.py
@@ -279,9 +279,6 @@ class ParameterRule(BaseModel):
     @classmethod
     def validate_label(cls, data: dict) -> dict:
         if isinstance(data, dict):
-            if not data.get("label"):
-                data["label"] = I18nObject(en_US=data["name"])
-
             # check if there is a template
             if "use_template" in data:
                 try:
@@ -294,6 +291,9 @@ class ParameterRule(BaseModel):
                     data = copy_default_parameter_rule
                 except ValueError:
                     pass
+            
+            if not data.get("label"):
+                data["label"] = I18nObject(en_US=data["name"])
 
         return data
 


### PR DESCRIPTION
when a llm's config use `use_template`,  it's label will display incorrect:
![image](https://github.com/user-attachments/assets/9a4ff0f5-671b-4ab6-af49-ec450034bcc9)


After fix:
![image](https://github.com/user-attachments/assets/92b9cb7e-ae18-4fd0-9467-bbff2e36470b)
