### PR TITLE
fix invoke llm raise error

### DIFF
--- a/python/dify_plugin/invocations/model/llm.py
+++ b/python/dify_plugin/invocations/model/llm.py
@@ -17,7 +17,7 @@ class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
     @overload
     def invoke(
         self,
-        model_config: LLMModelConfig,
+        model_config: LLMModelConfig | dict,
         prompt_messages: list[PromptMessage],
         tools: list[PromptMessageTool] | None = None,
         stop: list[str] | None = None,
@@ -27,7 +27,7 @@ class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
     @overload
     def invoke(
         self,
-        model_config: LLMModelConfig,
+        model_config: LLMModelConfig | dict,
         prompt_messages: list[PromptMessage],
         tools: list[PromptMessageTool] | None = None,
         stop: list[str] | None = None,
@@ -37,7 +37,7 @@ class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
     @overload
     def invoke(
         self,
-        model_config: LLMModelConfig,
+        model_config: LLMModelConfig | dict,
         prompt_messages: list[PromptMessage],
         tools: list[PromptMessageTool] | None = None,
         stop: list[str] | None = None,
@@ -46,7 +46,7 @@ class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
 
     def invoke(
         self,
-        model_config: LLMModelConfig,
+        model_config: LLMModelConfig | dict,
         prompt_messages: list[PromptMessage],
         tools: list[PromptMessageTool] | None = None,
         stop: list[str] | None = None,
@@ -55,6 +55,9 @@ class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
         """
         Invoke llm
         """
+        if isinstance(model_config, dict):
+            model_config = LLMModelConfig(**model_config)
+
         data = {
             **model_config.model_dump(),
             "prompt_messages": [message.model_dump() for message in prompt_messages],


### PR DESCRIPTION
when we define a tool's params with `model-selector` type,  and use it this way:
```
response = self.session.model.llm.invoke(
  model_config=tool_parameters.get('model'),
  prompt_messages=prompt_messages,
  stream=False
)
```

It will raise error:
```
Traceback (most recent call last):
  File "d:\database\.venv\Lib\site-packages\dify_plugin\core\server\io_server.py", line 92, in _execute_request_in_thread
    self._execute_request(
  File "d:\database\.venv\Lib\site-packages\dify_plugin\plugin.py", line 327, in _execute_request
    for message in response:
  File "d:\database\.venv\Lib\site-packages\dify_plugin\core\plugin_executor.py", line 76, in invoke_tool
    yield from tool.invoke(request.tool_parameters)
  File "D:\database\tools\query.py", line 65, in _invoke
    response = self.session.model.llm.invoke(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "d:\database\.venv\Lib\site-packages\dify_plugin\invocations\model\llm.py", line 49, in invoke
    **model_config.model_dump(),
      ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'model_dump'
```