### PR TITLE
feat: add llm blocking invoke

### DIFF
--- a/python/dify_plugin/interfaces/agent/__init__.py
+++ b/python/dify_plugin/interfaces/agent/__init__.py
@@ -18,7 +18,7 @@ class AgentToolIdentity(ToolIdentity):
 
 
 class AgentModelConfig(LLMModelConfig):
-    entity: AIModelEntity
+    entity: AIModelEntity | None = None
 
 
 class AgentScratchpadUnit(BaseModel):

--- a/python/dify_plugin/invocations/model/llm.py
+++ b/python/dify_plugin/invocations/model/llm.py
@@ -7,13 +7,12 @@ from dify_plugin.entities.model.llm import (
     LLMModelConfig,
     LLMResult,
     LLMResultChunk,
-    LLMUsage,
     SummaryResult,
 )
-from dify_plugin.entities.model.message import AssistantPromptMessage, PromptMessage, PromptMessageTool
+from dify_plugin.entities.model.message import PromptMessage, PromptMessageTool
 
 
-class LLMInvocation(BackwardsInvocation[LLMResultChunk | LLMResult]):
+class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
     @overload
     def invoke(
         self,
@@ -66,33 +65,13 @@ class LLMInvocation(BackwardsInvocation[LLMResultChunk | LLMResult]):
             "stream": stream,
         }
 
-        if stream:
-            response = self._backwards_invoke(
-                InvokeType.LLM,
-                LLMResultChunk,
-                data,
-            )
-            response = cast(Generator[LLMResultChunk, None, None], response)
-            return response
-
-        result = LLMResult(
-            model=model_config.model,
-            prompt_messages=prompt_messages,
-            message=AssistantPromptMessage(content=""),
-            usage=LLMUsage.empty_usage(),
-        )
-
-        assert isinstance(result.message.content, str)
-
-        for llm_result in self._backwards_invoke(
+        response = self._backwards_invoke(
             InvokeType.LLM,
-            LLMResult,
+            LLMResultChunk,
             data,
-        ):
-            llm_result = cast(LLMResult, llm_result)
-            result = llm_result
-
-        return result
+        )
+        response = cast(Generator[LLMResultChunk, None, None], response)
+        return response
 
 
 class SummaryInvocation(BackwardsInvocation[SummaryResult]):

--- a/python/dify_plugin/invocations/model/llm.py
+++ b/python/dify_plugin/invocations/model/llm.py
@@ -13,7 +13,7 @@ from dify_plugin.entities.model.llm import (
 from dify_plugin.entities.model.message import AssistantPromptMessage, PromptMessage, PromptMessageTool
 
 
-class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
+class LLMInvocation(BackwardsInvocation[LLMResultChunk | LLMResult]):
     @overload
     def invoke(
         self,
@@ -86,22 +86,11 @@ class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
 
         for llm_result in self._backwards_invoke(
             InvokeType.LLM,
-            LLMResultChunk,
+            LLMResult,
             data,
         ):
-            if isinstance(llm_result.delta.message.content, str):
-                result.message.content += llm_result.delta.message.content
-
-            if llm_result.delta.usage:
-                result.usage.prompt_tokens += llm_result.delta.usage.prompt_tokens
-                result.usage.completion_tokens += llm_result.delta.usage.completion_tokens
-                result.usage.total_tokens += llm_result.delta.usage.total_tokens
-
-                result.usage.completion_price = llm_result.delta.usage.completion_price
-                result.usage.prompt_price = llm_result.delta.usage.prompt_price
-                result.usage.total_price = llm_result.delta.usage.total_price
-                result.usage.currency = llm_result.delta.usage.currency
-                result.usage.latency = llm_result.delta.usage.latency
+            llm_result = cast(LLMResult, llm_result)
+            result = llm_result
 
         return result
 


### PR DESCRIPTION
Added support for calling blocking model methods from within plugins to enable non-streaming Function Call invocations. The related PRs are as follows:
https://github.com/langgenius/dify/pull/15732