### PR TITLE
Fix: replace param `max_tokens` to `max_completetion_tokens`

### DIFF
--- a/python/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -125,7 +125,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                 endpoint_url += "/"
 
             # prepare the payload for a simple ping to the model
-            data = {"model": model, "max_tokens": 5}
+            data = {"model": model, "max_completion_tokens": 5}
 
             completion_type = LLMMode.value_of(credentials["mode"])
 


### PR DESCRIPTION
`max_tokens` is deprecated

See https://platform.openai.com/docs/api-reference/chat/create#chat-create-max_tokens