### PR TITLE
Fix the error in running the agent plugin

### DIFF
--- a/python/dify_plugin/interfaces/agent/__init__.py
+++ b/python/dify_plugin/interfaces/agent/__init__.py
@@ -18,7 +18,7 @@ class AgentToolIdentity(ToolIdentity):
 
 
 class AgentModelConfig(LLMModelConfig):
-    entity: AIModelEntity
+    entity: Optional[AIModelEntity] = Field(default=None)
 
 
 class AgentScratchpadUnit(BaseModel):


### PR DESCRIPTION
[dify-plugin-tod_agent#1](https://github.com/svcvit/dify-plugin-tod_agent/issues/1)
[#14562](https://github.com/langgenius/dify/issues/14562)
[#14904](https://github.com/langgenius/dify/issues/14904)
[#15830](https://github.com/langgenius/dify/issues/15830)
set the default value of entity in the `AgentModelConfig` class to None.
Thanks to [HamaWhiteGG](https://github.com/svcvit/dify-plugin-tod_agent/issues/1#issuecomment-2721520006) for the solution.