### PR TITLE
feat: add 'encouraged_response_prefix' parameter for LLM

### DIFF
--- a/python/dify_plugin/entities/model/__init__.py
+++ b/python/dify_plugin/entities/model/__init__.py
@@ -20,6 +20,7 @@ class DefaultParameterName(Enum):
     MAX_TOKENS = "max_tokens"
     RESPONSE_FORMAT = "response_format"
     JSON_SCHEMA = "json_schema"
+    ENCOURAGED_RESPONSE_PREFIX = "encouraged_response_prefix"
 
     @classmethod
     def value_of(cls, value: Any) -> "DefaultParameterName":
@@ -157,6 +158,21 @@ PARAMETER_RULE_TEMPLATE: dict[DefaultParameterName, dict] = {
         "help": {
             "en_US": "Set a response json schema will ensure LLM to adhere it.",
             "zh_Hans": "设置返回的json schema，llm将按照它返回",
+        },
+        "required": False,
+    },
+    DefaultParameterName.ENCOURAGED_RESPONSE_PREFIX: {
+        # For example, add the "<think>\n" prefix for DeepSeek R1 serial models:
+        # 1. https://github.com/deepseek-ai/DeepSeek-R1/commit/7ca5e1e7f75e12a1c561fffaa6aa686708f881ae
+        # 2. https://api-docs.deepseek.com/zh-cn/guides/chat_prefix_completion
+        "label": {
+            "en_US": "Encouraged response prefix",
+            "zh_Hans": "引导回复前缀",
+        },
+        "type": "text",
+        "help": {
+            "en_US": "Encourage the model to response with the prefix.",
+            "zh_Hans": "引导模型回复的前缀",
         },
         "required": False,
     },

--- a/python/dify_plugin/entities/model/message.py
+++ b/python/dify_plugin/entities/model/message.py
@@ -201,6 +201,7 @@ class AssistantPromptMessage(PromptMessage):
 
     role: PromptMessageRole = PromptMessageRole.ASSISTANT
     tool_calls: list[ToolCall] = []
+    encouraged_response_prefixed: Optional[bool] = None
 
     def is_empty(self) -> bool:
         """

--- a/python/dify_plugin/interfaces/model/large_language_model.py
+++ b/python/dify_plugin/interfaces/model/large_language_model.py
@@ -8,11 +8,12 @@ from typing import Optional, Union
 from pydantic import ConfigDict
 
 from dify_plugin.entities.model import (
+    DefaultParameterName,
     ModelPropertyKey,
     ModelType,
     ParameterRule,
     ParameterType,
-    PriceType, DefaultParameterName,
+    PriceType,
 )
 from dify_plugin.entities.model.llm import (
     LLMMode,
@@ -581,9 +582,8 @@ if you are not sure about the structure.
 
         model_parameters = self._validate_and_filter_model_parameters(model, model_parameters, credentials)
 
-        # deal with the prompt messages
-        encouraged_response_prefix = model_parameters.get(DefaultParameterName.ENCOURAGED_RESPONSE_PREFIX.value, "")
-        if encouraged_response_prefix is not None and encouraged_response_prefix != "":
+        # add encouraged_response_prefix if it's enabled
+        if (encouraged_response_prefix := model_parameters.get(DefaultParameterName.ENCOURAGED_RESPONSE_PREFIX.value, "")) != "":
             if len(prompt_messages) > 0 and not isinstance(prompt_messages[-1], AssistantPromptMessage):
                 prompt_messages.append(AssistantPromptMessage(content=encouraged_response_prefix,
                                                               encouraged_response_prefix=True))

--- a/python/dify_plugin/interfaces/model/large_language_model.py
+++ b/python/dify_plugin/interfaces/model/large_language_model.py
@@ -12,7 +12,7 @@ from dify_plugin.entities.model import (
     ModelType,
     ParameterRule,
     ParameterType,
-    PriceType,
+    PriceType, DefaultParameterName,
 )
 from dify_plugin.entities.model.llm import (
     LLMMode,
@@ -580,6 +580,13 @@ if you are not sure about the structure.
             model_parameters = {}
 
         model_parameters = self._validate_and_filter_model_parameters(model, model_parameters, credentials)
+
+        # deal with the prompt messages
+        encouraged_response_prefix = model_parameters.get(DefaultParameterName.ENCOURAGED_RESPONSE_PREFIX.value, "")
+        if encouraged_response_prefix is not None and encouraged_response_prefix != "":
+            if len(prompt_messages) > 0 and not isinstance(prompt_messages[-1], AssistantPromptMessage):
+                prompt_messages.append(AssistantPromptMessage(content=encouraged_response_prefix,
+                                                              encouraged_response_prefix=True))
 
         self.started_at = time.perf_counter()
 


### PR DESCRIPTION
Add a new 'encouraged_response_prefix' parameter for LLMs, for example, it's helpful to achieve the [Chat Prefix Completion](https://api-docs.deepseek.com/guides/chat_prefix_completion) feature of DeepSeek models.