### PR TITLE
fix:Let OAICompatLargeLanguageModel compatible with the ​"data:" format for streaming response messages

### DIFF
--- a/python/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -504,7 +504,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                 # ignore sse comments
                 if chunk.startswith(":"):
                     continue
-                decoded_chunk = chunk.strip().removeprefix("data: ").lstrip()
+                decoded_chunk = chunk.strip().removeprefix("data:").lstrip()
                 if decoded_chunk == "[DONE]":  # Some provider returns "data: [DONE]"
                     continue
 


### PR DESCRIPTION
fix:Let OAICompatLargeLanguageModel compatible with the ​"data:" format for streaming response messages 
related issues:https://github.com/langgenius/dify/issues/15486