### PR TITLE
fix: bypass _code_block_mode_wrapper if response_format is not JSON or XML

### DIFF
--- a/python/dify_plugin/interfaces/model/large_language_model.py
+++ b/python/dify_plugin/interfaces/model/large_language_model.py
@@ -521,7 +521,7 @@ if you are not sure about the structure.
                         message=AssistantPromptMessage(content=new_piece, tool_calls=[]),
                     ),
                 )
-    
+
     def _wrap_thinking_by_reasoning_content(self, delta: dict, is_reasoning: bool) -> tuple[str, bool]:
         """
         If the reasoning response is from delta.get("reasoning_content"), we wrap
@@ -584,7 +584,7 @@ if you are not sure about the structure.
         self.started_at = time.perf_counter()
 
         try:
-            if "response_format" in model_parameters:
+            if "response_format" in model_parameters and model_parameters["response_format"] in {"JSON", "XML"}:
                 result = self._code_block_mode_wrapper(
                     model=model,
                     credentials=credentials,


### PR DESCRIPTION
This is regression of #8451, and re-application of #9148 by @hjlarry.

Related issues and PRs:

- https://github.com/langgenius/dify-official-plugins/issues/477
- https://github.com/langgenius/dify-official-plugins/issues/425
- https://github.com/langgenius/dify/issues/14475
- https://github.com/langgenius/dify-plugin-sdks/issues/28
- https://github.com/langgenius/dify-plugin-sdks/pull/29

In the current implementation, `self._code_block_mode_wrapper` is executed when the `response_format` is `json_schema`, but this method is intended to force output format to `JSON` or `XML` that is independently implemented by Dify itself, and not for the Structured Output feature that the LLM model possesses.

When this method is called when the `response_format` is neither `JSON` nor `XML` such as `json_schema`, the `model_parameters` and prompts can be formatted in an unintended way by the LLM, leading to errors in subsequent processing.

Closes #28 