### PR TITLE
feat(python): Integrate flake8-builtins (A) ruleset with ruff

### DIFF
--- a/python/.ruff.toml
+++ b/python/.ruff.toml
@@ -37,6 +37,10 @@ select = [
     # https://docs.astral.sh/ruff/rules/#flake8-bandit-s
     "S",
 
+    # avoid shadowing builtins
+    # https://docs.astral.sh/ruff/rules/#flake8-builtins-a
+    "A",
+
     # prohibit calls to `breakpoint()` in committed code
     # https://docs.astral.sh/ruff/rules/#flake8-debugger-t10
     "T10",

--- a/python/dify_plugin/core/runtime.py
+++ b/python/dify_plugin/core/runtime.py
@@ -169,7 +169,7 @@ class BackwardsInvocation(Generic[T], ABC):
 
     def _backwards_invoke(
         self,
-        type: InvokeType,
+        type: InvokeType,  # noqa: A002
         data_type: type[T],
         data: dict,
     ) -> Generator[T, None, None]:
@@ -224,7 +224,7 @@ class BackwardsInvocation(Generic[T], ABC):
     def _http_backwards_invoke(
         self,
         backwards_request_id: str,
-        type: InvokeType,
+        type: InvokeType,  # noqa: A002
         data_type: type[T],
         data: dict,
     ) -> Generator[T, None, None]:
@@ -283,7 +283,7 @@ class BackwardsInvocation(Generic[T], ABC):
     def _full_duplex_backwards_invoke(
         self,
         backwards_request_id: str,
-        type: InvokeType,
+        type: InvokeType,  # noqa: A002
         data_type: type[T],
         data: dict,
     ) -> Generator[T, None, None]:
@@ -301,7 +301,7 @@ class BackwardsInvocation(Generic[T], ABC):
             ),
         )
 
-        def filter(data: PluginInStream) -> bool:
+        def filter(data: PluginInStream) -> bool:  # noqa: A001
             return (
                 data.event == PluginInStreamEvent.BackwardInvocationResponse
                 and data.data.get("backwards_request_id") == backwards_request_id

--- a/python/dify_plugin/core/server/__base/filter_reader.py
+++ b/python/dify_plugin/core/server/__base/filter_reader.py
@@ -13,7 +13,7 @@ class FilterReader:
 
     def __init__(
         self,
-        filter: Callable[[PluginInStream], bool],
+        filter: Callable[[PluginInStream], bool],  # noqa: A002
         close_callback: Optional[Callable] = None,
     ) -> None:
         self.filter = filter

--- a/python/dify_plugin/core/server/__base/request_reader.py
+++ b/python/dify_plugin/core/server/__base/request_reader.py
@@ -45,7 +45,7 @@ class RequestReader(ABC):
                 data={"error": f"Failed to process request ({type(e).__name__}): {str(e)}"},
             )
 
-    def read(self, filter: Callable[["PluginInStream"], bool]) -> FilterReader:
+    def read(self, filter: Callable[["PluginInStream"], bool]) -> FilterReader:  # noqa: A002
         def close(reader: FilterReader):
             with self.lock:
                 self.readers.remove(reader)

--- a/python/dify_plugin/core/server/io_server.py
+++ b/python/dify_plugin/core/server/io_server.py
@@ -57,7 +57,7 @@ class IOServer(ABC):
         start listen to stdin and dispatch task to executor
         """
 
-        def filter(data: PluginInStream) -> bool:
+        def filter(data: PluginInStream) -> bool:  # noqa: A001
             return data.event == PluginInStreamEvent.Request
 
         for data in self.request_reader.read(filter).read():
@@ -142,8 +142,8 @@ class IOServer(ABC):
         """
         while True:
             time.sleep(0.5)
-            id = os.getppid()
-            if id == 1:
+            parent_process_id = os.getppid()
+            if parent_process_id == 1:
                 os._exit(-1)
 
     def _run(self):

--- a/python/dify_plugin/core/server/router.py
+++ b/python/dify_plugin/core/server/router.py
@@ -14,7 +14,7 @@ class Route:
     filter: Callable[[dict], bool]
     func: Callable
 
-    def __init__(self, filter: Callable[[dict], bool], func) -> None:
+    def __init__(self, filter: Callable[[dict], bool], func) -> None:  # noqa: A002
         self.filter = filter
         self.func = func
 
@@ -28,7 +28,7 @@ class Router:
         self.request_reader = request_reader
         self.response_writer = response_writer
 
-    def register_route(self, f: Callable, filter: Callable[[dict], bool], instance: Any = None):
+    def register_route(self, f: Callable, filter: Callable[[dict], bool], instance: Any = None):  # noqa: A002
         sig = inspect.signature(f)
         parameters = list(sig.parameters.values())
         if len(parameters) == 0:

--- a/python/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -438,7 +438,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
         chunk_index = 0
 
         def create_final_llm_result_chunk(
-            id: Optional[str],
+            id: Optional[str],  # noqa: A002
             index: int,
             message: AssistantPromptMessage,
             finish_reason: str,

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -335,9 +335,9 @@ class Plugin(IOServer, Router):
                         message.message, ToolInvokeMessage.BlobMessage
                     ):
                         # convert blob to file chunks
-                        id = uuid.uuid4().hex
+                        id_ = uuid.uuid4().hex
                         blob = message.message.blob
-                        message.message.blob = id.encode("utf-8")
+                        message.message.blob = id_.encode("utf-8")
                         # split the blob into chunks
                         chunks = [blob[i : i + 8192] for i in range(0, len(blob), 8192)]
                         for sequence, chunk in enumerate(chunks):
@@ -347,7 +347,7 @@ class Plugin(IOServer, Router):
                                     data=ToolInvokeMessage(
                                         type=ToolInvokeMessage.MessageType.BLOB_CHUNK,
                                         message=ToolInvokeMessage.BlobChunkMessage(
-                                            id=id,
+                                            id=id_,
                                             sequence=sequence,
                                             total_length=len(blob),
                                             blob=chunk,
@@ -365,7 +365,7 @@ class Plugin(IOServer, Router):
                                 data=ToolInvokeMessage(
                                     type=ToolInvokeMessage.MessageType.BLOB_CHUNK,
                                     message=ToolInvokeMessage.BlobChunkMessage(
-                                        id=id,
+                                        id=id_,
                                         sequence=len(chunks),
                                         total_length=len(blob),
                                         blob=b"",


### PR DESCRIPTION
Introduce the flake8-builtins (A) ruleset to prevent accidental shadowing of Python's built-in functions.

Address existing issues primarily by adding `# noqa` to suppress warnings where necessary.