### PR TITLE
feat(python): Enforce FBT003 rule in ruff for boolean arguments

### DIFF
--- a/python/.ruff.toml
+++ b/python/.ruff.toml
@@ -44,6 +44,12 @@ select = [
     # prohibit calls to `breakpoint()` in committed code
     # https://docs.astral.sh/ruff/rules/#flake8-debugger-t10
     "T10",
+
+    # disallow calling functions with boolean positional
+    # arguments.
+    #
+    # https://docs.astral.sh/ruff/rules/boolean-positional-value-in-call/
+    "FBT003",
 ]
 
 ignore = [


### PR DESCRIPTION
Configure ruff to require boolean arguments to be passed as keyword arguments in function calls. This enhances code readability and clarity at call sites.