### PR TITLE
Fix: handle the situation which OpenAI compatible LLM responses error messages

### DIFF
--- a/python/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -532,6 +532,8 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                         usage=usage or {},
                     )
                     break
+                if chunk_json and (e := chunk_json.get("error")):
+                    raise ValueError(e)
                 if chunk_json and (u := chunk_json.get("usage")):
                     usage = u
                 if not chunk_json or len(chunk_json["choices"]) == 0:


### PR DESCRIPTION
To handle this situation.
![image](https://github.com/user-attachments/assets/a15b10de-3dd9-440c-bf31-b6ec9a5743b1)
