### PR TITLE
fix: invalid new tool call creation logic during streaming response handling in OAI-Compat model.

### DIFF
--- a/python/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -475,7 +475,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
     ) -> list[AssistantPromptMessage.ToolCall]:
         for new_tool_call in new_tool_calls:
             # get tool call
-            tool_call, tools_calls = self._get_tool_call(new_tool_call.function.name, tools_calls)
+            tool_call, tools_calls = self._get_tool_call(new_tool_call.id, tools_calls)
             # update tool call
             if new_tool_call.id:
                 tool_call.id = new_tool_call.id


### PR DESCRIPTION
Differentiate new tool call instance by function name rather than tool call ID.

Sync logic from Dify main project:
[https://github.com/langgenius/dify/blob/c9f18aae0fca88ec7c440e60b6153333a64d14bb/api/core/model_runtime/model_providers/__base/large_language_model.py#L112C17-L142C1](https://github.com/langgenius/dify/blob/c9f18aae0fca88ec7c440e60b6153333a64d14bb/api/core/model_runtime/model_providers/__base/large_language_model.py#L112C17-L142C1)