### PR TITLE
enhancement: remove prompt_messages from LLMResult and LLMResultChunk

### DIFF
--- a/python/dify_plugin/entities/model/llm.py
+++ b/python/dify_plugin/entities/model/llm.py
@@ -7,7 +7,6 @@ from pydantic import BaseModel, ConfigDict, Field
 from dify_plugin.entities.model import BaseModelConfig, ModelType, ModelUsage, PriceInfo
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
-    PromptMessage,
 )
 
 
@@ -86,7 +85,6 @@ class LLMResultChunk(BaseModel):
     """
 
     model: str
-    prompt_messages: list[PromptMessage]
     system_fingerprint: Optional[str] = None
     delta: LLMResultChunkDelta
 
@@ -97,7 +95,6 @@ class LLMResult(BaseModel):
     """
 
     model: str
-    prompt_messages: list[PromptMessage]
     message: AssistantPromptMessage
     usage: LLMUsage
     system_fingerprint: Optional[str] = None
@@ -105,7 +102,6 @@ class LLMResult(BaseModel):
     def to_llm_result_chunk(self) -> "LLMResultChunk":
         return LLMResultChunk(
             model=self.model,
-            prompt_messages=self.prompt_messages,
             system_fingerprint=self.system_fingerprint,
             delta=LLMResultChunkDelta(
                 index=0,

--- a/python/dify_plugin/entities/model/llm.py
+++ b/python/dify_plugin/entities/model/llm.py
@@ -86,7 +86,7 @@ class LLMResultChunk(BaseModel):
     """
 
     model: str
-    prompt_messages: list[PromptMessage]
+    prompt_messages: list[PromptMessage] = Field(default_factory=list)
     system_fingerprint: Optional[str] = None
     delta: LLMResultChunkDelta
 
@@ -111,7 +111,7 @@ class LLMResult(BaseModel):
     """
 
     model: str
-    prompt_messages: list[PromptMessage]
+    prompt_messages: list[PromptMessage] = Field(default_factory=list)
     message: AssistantPromptMessage
     usage: LLMUsage
     system_fingerprint: Optional[str] = None

--- a/python/dify_plugin/entities/model/llm.py
+++ b/python/dify_plugin/entities/model/llm.py
@@ -2,11 +2,12 @@ from decimal import Decimal
 from enum import Enum
 from typing import Optional
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from dify_plugin.entities.model import BaseModelConfig, ModelType, ModelUsage, PriceInfo
 from dify_plugin.entities.model.message import (
     AssistantPromptMessage,
+    PromptMessage,
 )
 
 
@@ -85,8 +86,23 @@ class LLMResultChunk(BaseModel):
     """
 
     model: str
+    prompt_messages: list[PromptMessage]
     system_fingerprint: Optional[str] = None
     delta: LLMResultChunkDelta
+
+    @field_validator("prompt_messages", mode="before")
+    def transform_prompt_messages(cls, value):
+        """
+        ISSUE:
+        - https://github.com/langgenius/dify/issues/17799
+        - https://github.com/langgenius/dify-official-plugins/issues/648
+
+        The `prompt_messages` field is deprecated, but to keep backward compatibility
+        we need to always set it to an empty list.
+
+        NOTE: just do not use it anymore, it will be removed in the future.
+        """
+        return []
 
 
 class LLMResult(BaseModel):
@@ -95,9 +111,24 @@ class LLMResult(BaseModel):
     """
 
     model: str
+    prompt_messages: list[PromptMessage]
     message: AssistantPromptMessage
     usage: LLMUsage
     system_fingerprint: Optional[str] = None
+
+    @field_validator("prompt_messages", mode="before")
+    def transform_prompt_messages(cls, value):
+        """
+        ISSUE:
+        - https://github.com/langgenius/dify/issues/17799
+        - https://github.com/langgenius/dify-official-plugins/issues/648
+
+        The `prompt_messages` field is deprecated, but to keep backward compatibility
+        we need to always set it to an empty list.
+
+        NOTE: just do not use it anymore, it will be removed in the future.
+        """
+        return []
 
     def to_llm_result_chunk(self) -> "LLMResultChunk":
         return LLMResultChunk(

--- a/python/dify_plugin/entities/model/message.py
+++ b/python/dify_plugin/entities/model/message.py
@@ -188,6 +188,7 @@ def _ensure_field_empty_str(value: Optional[str]) -> str:
         return ""
     return value
 
+
 class AssistantPromptMessage(PromptMessage):
     """
     Model class for assistant prompt message.

--- a/python/dify_plugin/interfaces/model/large_language_model.py
+++ b/python/dify_plugin/interfaces/model/large_language_model.py
@@ -440,7 +440,6 @@ if you are not sure about the structure.
             if new_piece:
                 yield LLMResultChunk(
                     model=model,
-                    prompt_messages=prompt_messages,
                     delta=LLMResultChunkDelta(
                         index=0,
                         message=AssistantPromptMessage(content=new_piece, tool_calls=[]),
@@ -515,7 +514,6 @@ if you are not sure about the structure.
                 # Only yield content collected within the code block
                 yield LLMResultChunk(
                     model=model,
-                    prompt_messages=prompt_messages,
                     delta=LLMResultChunkDelta(
                         index=0,
                         message=AssistantPromptMessage(content=new_piece, tool_calls=[]),

--- a/python/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -164,7 +164,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
 
             try:
                 json_result = response.json()
-            except json.JSONDecodeError as e:
+            except json.JSONDecodeError:
                 raise CredentialsValidateFailedError("Credentials validation failed: JSON decode error")
 
             if completion_type is LLMMode.CHAT and json_result.get("object", "") == "":
@@ -444,7 +444,6 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
 
         return LLMResultChunk(
             model=model,
-            prompt_messages=prompt_messages,
             delta=LLMResultChunkDelta(index=index, message=message, finish_reason=finish_reason, usage=usage),
         )
 
@@ -521,7 +520,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                 try:
                     chunk_json: dict = json.loads(decoded_chunk)
                 # stream ended
-                except json.JSONDecodeError as e:
+                except json.JSONDecodeError:
                     yield self._create_final_llm_result_chunk(
                         index=chunk_index + 1,
                         message=AssistantPromptMessage(content=""),
@@ -594,7 +593,6 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
 
                 yield LLMResultChunk(
                     model=model,
-                    prompt_messages=prompt_messages,
                     delta=LLMResultChunkDelta(
                         index=chunk_index,
                         message=assistant_prompt_message,
@@ -606,7 +604,6 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
         if tools_calls:
             yield LLMResultChunk(
                 model=model,
-                prompt_messages=prompt_messages,
                 delta=LLMResultChunkDelta(
                     index=chunk_index,
                     message=AssistantPromptMessage(tool_calls=tools_calls, content=""),
@@ -678,7 +675,6 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
         result = LLMResult(
             id=message_id,
             model=response_json["model"],
-            prompt_messages=prompt_messages,
             message=assistant_message,
             usage=usage,
         )

--- a/python/dify_plugin/invocations/model/llm.py
+++ b/python/dify_plugin/invocations/model/llm.py
@@ -77,7 +77,6 @@ class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
 
         result = LLMResult(
             model=model_config.model,
-            prompt_messages=prompt_messages,
             message=AssistantPromptMessage(content=""),
             usage=LLMUsage.empty_usage(),
         )

--- a/python/examples/agent/output_parser/cot_output_parser.py
+++ b/python/examples/agent/output_parser/cot_output_parser.py
@@ -45,9 +45,7 @@ class CotAgentOutputParser:
             if not code_blocks:
                 return
             for block in code_blocks:
-                json_text = re.sub(
-                    r"^[a-zA-Z]+\n", "", block.strip(), flags=re.MULTILINE
-                )
+                json_text = re.sub(r"^[a-zA-Z]+\n", "", block.strip(), flags=re.MULTILINE)
                 yield parse_action(json_text)
 
         code_block_cache = ""

--- a/python/examples/jina/models/text_embedding/text_embedding.py
+++ b/python/examples/jina/models/text_embedding/text_embedding.py
@@ -105,7 +105,7 @@ class JinaTextEmbeddingModel(TextEmbeddingModel):
             usage = resp["usage"]
         except Exception as e:
             raise InvokeServerUnavailableError(
-                "Failed to convert response to json: " f"{e} with text: {response.text}"
+                f"Failed to convert response to json: {e} with text: {response.text}"
             ) from e
 
         usage = self._calc_response_usage(model=model, credentials=credentials, tokens=usage["total_tokens"])

--- a/python/examples/openai/models/llm/llm.py
+++ b/python/examples/openai/models/llm/llm.py
@@ -518,7 +518,6 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         # transform response
         result = LLMResult(
             model=response.model,
-            prompt_messages=prompt_messages,
             message=assistant_prompt_message,
             usage=usage,
             system_fingerprint=response.system_fingerprint,
@@ -548,7 +547,6 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
 
         final_chunk = LLMResultChunk(
             model=model,
-            prompt_messages=prompt_messages,
             delta=LLMResultChunkDelta(
                 index=0,
                 message=AssistantPromptMessage(content=""),
@@ -577,7 +575,6 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             if delta.finish_reason is not None:
                 final_chunk = LLMResultChunk(
                     model=chunk.model,
-                    prompt_messages=prompt_messages,
                     system_fingerprint=chunk.system_fingerprint,
                     delta=LLMResultChunkDelta(
                         index=delta.index,
@@ -588,7 +585,6 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             else:
                 yield LLMResultChunk(
                     model=chunk.model,
-                    prompt_messages=prompt_messages,
                     system_fingerprint=chunk.system_fingerprint,
                     delta=LLMResultChunkDelta(
                         index=delta.index,
@@ -731,7 +727,6 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         # transform response
         return LLMResult(
             model=response.model,
-            prompt_messages=prompt_messages,
             message=assistant_prompt_message,
             usage=usage,
             system_fingerprint=response.system_fingerprint,
@@ -761,7 +756,6 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         final_tool_calls = []
         final_chunk = LLMResultChunk(
             model=model,
-            prompt_messages=prompt_messages,
             delta=LLMResultChunkDelta(
                 index=0,
                 message=AssistantPromptMessage(content=""),
@@ -829,7 +823,6 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             if has_finish_reason:
                 final_chunk = LLMResultChunk(
                     model=chunk.model,
-                    prompt_messages=prompt_messages,
                     system_fingerprint=chunk.system_fingerprint,
                     delta=LLMResultChunkDelta(
                         index=delta.index,
@@ -840,7 +833,6 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             else:
                 yield LLMResultChunk(
                     model=chunk.model,
-                    prompt_messages=prompt_messages,
                     system_fingerprint=chunk.system_fingerprint,
                     delta=LLMResultChunkDelta(
                         index=delta.index,

--- a/python/tests/test_llm_result.py
+++ b/python/tests/test_llm_result.py
@@ -1,9 +1,9 @@
-from dify_plugin.entities.model.llm import LLMResultChunk, LLMResultChunkDelta
+from dify_plugin.entities.model.llm import LLMResult, LLMResultChunk, LLMResultChunkDelta, LLMUsage
 from dify_plugin.entities.model.message import AssistantPromptMessage, TextPromptMessageContent
 
 
 def test_build_llm_result_chunk_with_prompt_messages():
-    prompt = LLMResultChunk(
+    chunk = LLMResultChunk(
         model="test",
         prompt_messages=[AssistantPromptMessage(content=[TextPromptMessageContent(data="Hello, World!")])],
         delta=LLMResultChunkDelta(
@@ -11,7 +11,7 @@ def test_build_llm_result_chunk_with_prompt_messages():
             message=AssistantPromptMessage(content=[TextPromptMessageContent(data="Hello, World!")]),
         ),
     )
-    assert isinstance(prompt.prompt_messages, list)
+    assert isinstance(chunk.prompt_messages, list)
     """
     NOTE:
     - https://github.com/langgenius/dify/issues/17799
@@ -20,4 +20,24 @@ def test_build_llm_result_chunk_with_prompt_messages():
     The `prompt_messages` field is deprecated, but to keep backward compatibility
     we need to always set it to an empty list.
     """
-    assert len(prompt.prompt_messages) == 0
+    assert len(chunk.prompt_messages) == 0
+
+
+def test_build_llm_result_with_prompt_messages():
+    result = LLMResult(
+        model="test",
+        prompt_messages=[AssistantPromptMessage(content=[TextPromptMessageContent(data="Hello, World!")])],
+        message=AssistantPromptMessage(content=[TextPromptMessageContent(data="Hello, World!")]),
+        usage=LLMUsage.empty_usage(),
+    )
+
+    assert isinstance(result.prompt_messages, list)
+    """
+    NOTE:
+    - https://github.com/langgenius/dify/issues/17799
+    - https://github.com/langgenius/dify-official-plugins/issues/648
+
+    The `prompt_messages` field is deprecated, but to keep backward compatibility
+    we need to always set it to an empty list.
+    """
+    assert len(result.prompt_messages) == 0

--- a/python/tests/test_llm_result.py
+++ b/python/tests/test_llm_result.py
@@ -1,0 +1,23 @@
+from dify_plugin.entities.model.llm import LLMResultChunk, LLMResultChunkDelta
+from dify_plugin.entities.model.message import AssistantPromptMessage, TextPromptMessageContent
+
+
+def test_build_llm_result_chunk_with_prompt_messages():
+    prompt = LLMResultChunk(
+        model="test",
+        prompt_messages=[AssistantPromptMessage(content=[TextPromptMessageContent(data="Hello, World!")])],
+        delta=LLMResultChunkDelta(
+            index=0,
+            message=AssistantPromptMessage(content=[TextPromptMessageContent(data="Hello, World!")]),
+        ),
+    )
+    assert isinstance(prompt.prompt_messages, list)
+    """
+    NOTE:
+    - https://github.com/langgenius/dify/issues/17799
+    - https://github.com/langgenius/dify-official-plugins/issues/648
+
+    The `prompt_messages` field is deprecated, but to keep backward compatibility
+    we need to always set it to an empty list.
+    """
+    assert len(prompt.prompt_messages) == 0

--- a/python/tests/test_tool_call_model_init.py
+++ b/python/tests/test_tool_call_model_init.py
@@ -9,7 +9,7 @@ def test_tool_call_model_init_with_explicit_none_fields():
             "arguments": None,
         },
         "id": None,
-        "type": None
+        "type": None,
     }
 
     try:
@@ -32,11 +32,7 @@ def test_tool_call_model_init_with_explicit_none_fields():
         assert tool_call.function.name == ""
         assert tool_call.function.arguments == ""
 
-    response_function_call = {
-        "name": None,
-        "arguments": None,
-        "id": None
-    }
+    response_function_call = {"name": None, "arguments": None, "id": None}
 
     try:
         function = AssistantPromptMessage.ToolCall.ToolCallFunction(
@@ -56,4 +52,3 @@ def test_tool_call_model_init_with_explicit_none_fields():
         assert tool_call.id == ""
         assert tool_call.function.name == ""
         assert tool_call.function.arguments == ""
-


### PR DESCRIPTION
Solves high CPU usage of dify-api container caused by LLMResultChunk decoding

Related: 
- https://github.com/langgenius/dify/issues/17799
- https://github.com/langgenius/dify-official-plugins/issues/648
