### PR TITLE
feat(python): Add specific error classes for StorageInvocation

### DIFF
--- a/python/dify_plugin/invocations/storage.py
+++ b/python/dify_plugin/invocations/storage.py
@@ -12,14 +12,6 @@ class StorageInvocationError(Exception):
     pass
 
 
-class NotFoundError(StorageInvocationError):
-    """NotFoundError is a subclass of StorageInvocationError, raised specifically
-    when attempting to retrieve or delete a key that does not exist.
-    """
-
-    pass
-
-
 class StorageInvocation(BackwardsInvocation[dict]):
     def set(self, key: str, val: bytes) -> None:
         """
@@ -55,14 +47,13 @@ class StorageInvocation(BackwardsInvocation[dict]):
         ):
             return unhexlify(data["data"])
 
-        raise NotFoundError("no data found")
+        raise StorageInvocationError("no data found")
 
     def delete(self, key: str) -> None:
         """delete a key from persistence storage.
 
         :raises:
             StorageInvocationError: If the invocation returns an invalid data.
-            NotFoundError: If the caller gets a key that does not exist.
         """
         for data in self._backwards_invoke(
             InvokeType.Storage,
@@ -77,9 +68,14 @@ class StorageInvocation(BackwardsInvocation[dict]):
 
             raise StorageInvocationError(f"unexpected data: {data['data']}")
 
-        raise NotFoundError("no data found")
+        raise StorageInvocationError("no data found")
 
     def exist(self, key: str) -> bool:
+        """Check for the existence of a key in persistence storage.
+
+        :raises:
+            StorageInvocationError: If the invocation does not return any data.
+        """
         for data in self._backwards_invoke(
             InvokeType.Storage,
             dict,
@@ -90,4 +86,4 @@ class StorageInvocation(BackwardsInvocation[dict]):
         ):
             return data["data"]
 
-        raise Exception("no data found")
+        raise StorageInvocationError("no data found")

--- a/python/dify_plugin/invocations/storage.py
+++ b/python/dify_plugin/invocations/storage.py
@@ -8,6 +8,7 @@ class StorageInvocationError(Exception):
     """StorageInvocationError is a custom exception raised
     when an issue occurs during the execution of a storage invocation.
     """
+
     pass
 
 
@@ -15,6 +16,7 @@ class NotFoundError(StorageInvocationError):
     """NotFoundError is a subclass of StorageInvocationError, raised specifically
     when attempting to retrieve or delete a key that does not exist.
     """
+
     pass
 
 

--- a/python/dify_plugin/invocations/storage.py
+++ b/python/dify_plugin/invocations/storage.py
@@ -4,10 +4,27 @@ from dify_plugin.core.entities.invocation import InvokeType
 from dify_plugin.core.runtime import BackwardsInvocation
 
 
+class StorageInvocationError(Exception):
+    """StorageInvocationError is a custom exception raised
+    when an issue occurs during the execution of a storage invocation.
+    """
+    pass
+
+
+class NotFoundError(StorageInvocationError):
+    """NotFoundError is a subclass of StorageInvocationError, raised specifically
+    when attempting to retrieve or delete a key that does not exist.
+    """
+    pass
+
+
 class StorageInvocation(BackwardsInvocation[dict]):
     def set(self, key: str, val: bytes) -> None:
         """
         set a value into persistence storage.
+
+        :raises:
+            StorageInvocationError: If the invocation returns an invalid data.
         """
         for data in self._backwards_invoke(
             InvokeType.Storage,
@@ -17,11 +34,15 @@ class StorageInvocation(BackwardsInvocation[dict]):
             if data["data"] == "ok":
                 return
 
-            raise Exception("unexpected data")
-
-        Exception("no data found")
+            raise StorageInvocationError(f"unexpected data: {data['data']}")
 
     def get(self, key: str) -> bytes:
+        """get a key from persistence storage.
+
+        :raises:
+            NotFoundError: If the caller gets a key that does not exist.
+        """
+
         for data in self._backwards_invoke(
             InvokeType.Storage,
             dict,
@@ -32,9 +53,15 @@ class StorageInvocation(BackwardsInvocation[dict]):
         ):
             return unhexlify(data["data"])
 
-        raise Exception("no data found")
+        raise NotFoundError("no data found")
 
     def delete(self, key: str) -> None:
+        """delete a key from persistence storage.
+
+        :raises:
+            StorageInvocationError: If the invocation returns an invalid data.
+            NotFoundError: If the caller gets a key that does not exist.
+        """
         for data in self._backwards_invoke(
             InvokeType.Storage,
             dict,
@@ -46,9 +73,9 @@ class StorageInvocation(BackwardsInvocation[dict]):
             if data["data"] == "ok":
                 return
 
-            raise Exception("unexpected data")
+            raise StorageInvocationError(f"unexpected data: {data['data']}")
 
-        raise Exception("no data found")
+        raise NotFoundError("no data found")
 
     def exist(self, key: str) -> bool:
         for data in self._backwards_invoke(

--- a/python/tests/invocations/test_storage.py
+++ b/python/tests/invocations/test_storage.py
@@ -5,7 +5,6 @@ import pytest
 
 from dify_plugin.core.entities.invocation import InvokeType
 from dify_plugin.invocations.storage import (
-    NotFoundError,
     StorageInvocation,
     StorageInvocationError,
 )
@@ -13,7 +12,6 @@ from dify_plugin.invocations.storage import (
 
 def test_error_hierarchy():
     assert issubclass(StorageInvocationError, Exception)
-    assert issubclass(NotFoundError, StorageInvocationError)
 
 
 class DummyStorageInvocation(StorageInvocation):
@@ -35,7 +33,7 @@ class DummyStorageInvocation(StorageInvocation):
 class TestStorageInvocationExceptionRaises:
     def test_get_should_raise_not_found_error_if_key_not_exist(self):
         storage = DummyStorageInvocation([])
-        with pytest.raises(NotFoundError):
+        with pytest.raises(StorageInvocationError):
             storage.get("test_key")
 
     def test_set_should_raise_storage_invocation_error_if_data_is_invalid(self):
@@ -50,11 +48,16 @@ class TestStorageInvocationExceptionRaises:
 
     def test_delete_should_raise_not_found_error_if_key_not_exist(self):
         storage = DummyStorageInvocation([])
-        with pytest.raises(NotFoundError):
+        with pytest.raises(StorageInvocationError):
             storage.delete("test_key")
 
+    def test_exist_should_raise_storage_invocation_error_if_data_is_invalid(self):
+        storage = DummyStorageInvocation([])
+        with pytest.raises(StorageInvocationError):
+            storage.exist("test_key")
 
-class TestSoterageInvocation:
+
+class TestStorageInvocation:
     def test_get_should_return_value(self):
         storage = DummyStorageInvocation([{"data": b"68656c6c6f"}])
         assert storage.get("test_key") == b"hello"
@@ -66,3 +69,10 @@ class TestSoterageInvocation:
     def test_delete(self):
         storage = DummyStorageInvocation([{"data": "ok"}])
         storage.delete("test_key")
+
+    def test_exist(self):
+        storage = DummyStorageInvocation([{"data": True}])
+        assert storage.exist("test_key")
+
+        storage = DummyStorageInvocation([{"data": False}])
+        assert not storage.exist("test_key")

--- a/python/tests/invocations/test_storage.py
+++ b/python/tests/invocations/test_storage.py
@@ -1,14 +1,14 @@
-from typing import Any, Generator
-
-from dify_plugin.invocations.storage import (
-    StorageInvocation,
-    StorageInvocationError,
-    NotFoundError,
-)
-from dify_plugin.core.entities.invocation import InvokeType
-
+from collections.abc import Generator
+from typing import Any
 
 import pytest
+
+from dify_plugin.core.entities.invocation import InvokeType
+from dify_plugin.invocations.storage import (
+    NotFoundError,
+    StorageInvocation,
+    StorageInvocationError,
+)
 
 
 def test_error_hierarchy():

--- a/python/tests/invocations/test_storage.py
+++ b/python/tests/invocations/test_storage.py
@@ -1,0 +1,68 @@
+from typing import Any, Generator
+
+from dify_plugin.invocations.storage import (
+    StorageInvocation,
+    StorageInvocationError,
+    NotFoundError,
+)
+from dify_plugin.core.entities.invocation import InvokeType
+
+
+import pytest
+
+
+def test_error_hierarchy():
+    assert issubclass(StorageInvocationError, Exception)
+    assert issubclass(NotFoundError, StorageInvocationError)
+
+
+class DummyStorageInvocation(StorageInvocation):
+    def __init__(self, return_values: list[dict]):
+        self._return_values = return_values
+
+    def _backwards_invoke(
+        self,
+        type: InvokeType,  # noqa: A002
+        data_type: Any,
+        data: dict,
+    ) -> Generator[dict, None, None]:
+        _ = type
+        _ = data_type
+        _ = data
+        yield from self._return_values
+
+
+class TestStorageInvocationExceptionRaises:
+    def test_get_should_raise_not_found_error_if_key_not_exist(self):
+        storage = DummyStorageInvocation([])
+        with pytest.raises(NotFoundError):
+            storage.get("test_key")
+
+    def test_set_should_raise_storage_invocation_error_if_data_is_invalid(self):
+        storage = DummyStorageInvocation([{"data": "invalid_data"}])
+        with pytest.raises(StorageInvocationError):
+            storage.set("test_key", b"test_value")
+
+    def test_delete_should_raise_storage_invocation_error_if_data_is_invalid(self):
+        storage = DummyStorageInvocation([{"data": "invalid_data"}])
+        with pytest.raises(StorageInvocationError):
+            storage.delete("test_key")
+
+    def test_delete_should_raise_not_found_error_if_key_not_exist(self):
+        storage = DummyStorageInvocation([])
+        with pytest.raises(NotFoundError):
+            storage.delete("test_key")
+
+
+class TestSoterageInvocation:
+    def test_get_should_return_value(self):
+        storage = DummyStorageInvocation([{"data": b"68656c6c6f"}])
+        assert storage.get("test_key") == b"hello"
+
+    def test_set_should_set_value(self):
+        storage = DummyStorageInvocation([{"data": "ok"}])
+        storage.set("test_key", b"test_value")
+
+    def test_delete(self):
+        storage = DummyStorageInvocation([{"data": "ok"}])
+        storage.delete("test_key")


### PR DESCRIPTION
Replace generic `Exception` raises with `NotFoundError` when the key is missing,
and `StorageInvocationError` for other response errors. This improves error
handling at call sites by avoiding overly generic exceptions.

Add correspond tests for exception raising logic.