### PR TITLE
fix(openai_compatible): set stream-tool-call's default value to not_support

### DIFF
--- a/python/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -1,6 +1,5 @@
 import codecs
 import json
-
 import logging
 from collections.abc import Generator
 from decimal import Decimal
@@ -187,7 +186,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
         except CredentialsValidateFailedError:
             raise
         except Exception as ex:
-            raise CredentialsValidateFailedError(f"An error occurred during credentials validation: {str(ex)}")
+            raise CredentialsValidateFailedError(f"An error occurred during credentials validation: {ex!s}")
 
     def get_customizable_model_schema(self, model: str, credentials: dict) -> AIModelEntity:
         """
@@ -201,7 +200,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
         elif function_calling_type == "tool_call":
             features.append(ModelFeature.MULTI_TOOL_CALL)
 
-        stream_function_calling = credentials.get("stream_function_calling", "supported")
+        stream_function_calling = credentials.get("stream_function_calling", "not_support")
         if stream_function_calling == "supported":
             features.append(ModelFeature.STREAM_TOOL_CALL)
 


### PR DESCRIPTION
## Descrption
Due to openai_compatible custom models having default support for stream_tool_call, Agent applications using these models will automatically select Function Call mode, resulting in execution.

Fixes https://github.com/langgenius/dify/issues/17917