### PR TITLE
chore: Limit CI pipeline to trigger only on main branch pushes

### DIFF
--- a/.github/workflows/mega-linter.yaml
+++ b/.github/workflows/mega-linter.yaml
@@ -9,6 +9,8 @@ on: # yamllint disable-line rule:truthy - false positive
   # Comment this line to trigger action only on pull-requests
   # (not recommended if you don't pay for GH Actions)
   push:
+    branches:
+      - main
 
   pull_request:
     branches:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -6,6 +6,8 @@ on: # yamllint disable-line rule:truthy - false positive
   # Comment this line to trigger action only on pull-requests
   # (not recommended if you don't pay for GH Actions)
   push:
+    branches:
+      - main
 
   pull_request:
     branches:


### PR DESCRIPTION
Previously, the `Pull Request` and the `MegaLinter` pipelines were triggered on pushes to any branch, including feature branches and other temporary branches. This behavior unnecessarily consumed CI execution quotas.

This change restricts the triggers for these pipelines, ensuring they only execute on pushes to the `main` branch.