### PR TITLE
fix: update minimum_dify_version to be optional in PluginConfiguration

### DIFF
--- a/python/dify_plugin/core/entities/plugin/setup.py
+++ b/python/dify_plugin/core/entities/plugin/setup.py
@@ -75,7 +75,7 @@ class PluginConfiguration(BaseModel):
         version: str
         arch: list[PluginArch]
         runner: PluginRunner
-        minimum_dify_version: Optional[str] = Field(..., pattern=r"^\d{1,4}(\.\d{1,4}){1,3}(-\w{1,16})?$")
+        minimum_dify_version: Optional[str] = Field(None, pattern=r"^\d{1,4}(\.\d{1,4}){1,3}(-\w{1,16})?$")
 
     version: str = Field(..., pattern=r"^\d{1,4}(\.\d{1,4}){1,3}(-\w{1,16})?$")
     type: PluginType

--- a/python/tests/entities/plugin/test_declaration.py
+++ b/python/tests/entities/plugin/test_declaration.py
@@ -1,0 +1,24 @@
+from dify_plugin.core.entities.plugin.setup import PluginArch, PluginConfiguration, PluginLanguage
+
+
+def test_optional_minimum_dify_required():
+    meta = PluginConfiguration.Meta(
+        version="1.0.0",
+        arch=[PluginArch.AMD64, PluginArch.ARM64],
+        runner=PluginConfiguration.Meta.PluginRunner(
+            language=PluginLanguage.PYTHON, version="3.10", entrypoint="main.py"
+        ),
+        minimum_dify_version="1.0.0",
+    )
+
+    assert meta.minimum_dify_version == "1.0.0"
+
+    meta = PluginConfiguration.Meta(
+        version="1.0.0",
+        arch=[PluginArch.AMD64, PluginArch.ARM64],
+        runner=PluginConfiguration.Meta.PluginRunner(
+            language=PluginLanguage.PYTHON, version="3.10", entrypoint="main.py"
+        ),
+    )
+
+    assert meta.minimum_dify_version is None


### PR DESCRIPTION
- Changed minimum_dify_version from required to optional in PluginConfiguration.
- Added unit tests to verify behavior when minimum_dify_version is not provided.