### PR TITLE
feat: support list in JsonMessage

### DIFF
--- a/python/dify_plugin/entities/tool.py
+++ b/python/dify_plugin/entities/tool.py
@@ -82,7 +82,7 @@ class ToolInvokeMessage(BaseModel):
             return {"text": self.text}
 
     class JsonMessage(BaseModel):
-        json_object: Mapping
+        json_object: Mapping | list
 
         def to_dict(self):
             return {"json_object": self.json_object}

--- a/python/dify_plugin/interfaces/tool/__init__.py
+++ b/python/dify_plugin/interfaces/tool/__init__.py
@@ -25,7 +25,7 @@ class ToolLike(ABC, Generic[T]):
             message=ToolInvokeMessage.TextMessage(text=text),
         )
 
-    def create_json_message(self, json: Mapping) -> T:
+    def create_json_message(self, json: Mapping | list) -> T:
         return self.response_type(
             type=ToolInvokeMessage.MessageType.JSON,
             message=ToolInvokeMessage.JsonMessage(json_object=json),


### PR DESCRIPTION
Add type `list` to JsonMessage. Now `Tool.create_json_message` can return a `list`.

```python
class JsonMessage(BaseModel):
    json_object: Mapping | list

    def to_dict(self):
        return {"json_object": self.json_object}
```

Example:
<img width="200" alt="2025-04-28 20 28 05" src="https://github.com/user-attachments/assets/cffc4337-53e0-4898-8165-2376b555dbfe" />

Note that corresponding support needs to be added simultaneously in [https://github.com/langgenius/dify](https://github.com/langgenius/dify)
Relevent PR in Dify: [#19026](https://github.com/langgenius/dify/pull/19026) 
