### PR TITLE
fix: In debug mode, thread locks block responses and heartbeats, causing TCP to reconnect.

### DIFF
--- a/python/dify_plugin/core/server/tcp/request_reader.py
+++ b/python/dify_plugin/core/server/tcp/request_reader.py
@@ -76,8 +76,7 @@ class TCPReaderWriter(RequestReader, ResponseWriter):
         """
         Receive data from the socket
         """
-        with self.opt_lock:
-            return self.sock.recv(size)
+        return self.sock.recv(size)
 
     def write(self, data: str):
         if not self.alive:


### PR DESCRIPTION
# Summary
In debug mode, thread locks block responses and heartbeats, causing TCP to reconnect.
fixes #98 

# Screenshots

![image](https://github.com/user-attachments/assets/806ac929-89cb-4fbd-ace3-38f9e230b77a)

# Checklist

> [!IMPORTANT]
> Please review the checklist below before submitting your pull request.:

- [ ]  This change requires a documentation update, included: [Dify Document](https://github.com/langgenius/dify-docs)
- [x]  I understand that this PR may be closed in case there was no previous discussion or issues. (This doesn't apply to typos!)
- [x]  I've added a test for each change that was introduced, and I tried as much as possible to make a single atomic change.
- [x]  I've updated the documentation accordingly.
- [x]  I ran dev/reformat(backend) and cd web && npx lint-staged(frontend) to appease the lint gods













