### PR TITLE
chore: update GitHub Actions permissions in mkdocs workflow

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -6,7 +6,7 @@ on:
       - main
 
 permissions:
-  contents: read
+  contents: write
   pages: write
   id-token: write
 


### PR DESCRIPTION
- Changed permissions for contents from read to write to allow for documentation deployment.