### PR TITLE
fix: improve buffer handling for multimodal input

### DIFF
--- a/python/dify_plugin/core/server/stdio/request_reader.py
+++ b/python/dify_plugin/core/server/stdio/request_reader.py
@@ -17,13 +17,15 @@ class StdioRequestReader(RequestReader):
     def __init__(self):
         super().__init__()
 
+    def _read_async(self) -> bytes:
+        # read data from stdin using tp_read in 64KB chunks.
+        # the OS buffer for stdin is usually 64KB, so using a larger value doesn't make sense.
+        return tp_read(sys.stdin.fileno(), 65536)
+
     def _read_stream(self) -> Generator[PluginInStream, None, None]:
         buffer = b""
         while True:
-            # read data from stdin using tp_read in 64KB chunks.
-            # the OS buffer for stdin is usually 64KB, so using a larger value doesn't make sense.
-            data = tp_read(sys.stdin.fileno(), 65536)
-
+            data = self._read_async()
             if not data:
                 continue
 

--- a/python/dify_plugin/core/server/stdio/request_reader.py
+++ b/python/dify_plugin/core/server/stdio/request_reader.py
@@ -41,6 +41,10 @@ class StdioRequestReader(RequestReader):
 
             lines = lines[:-1]
             for line in lines:
+                line = line.strip()
+                if not line:
+                    continue
+
                 try:
                     data = TypeAdapter(dict[str, Any]).validate_json(line)
                     yield PluginInStream(

--- a/python/tests/servers/test_stdio.py
+++ b/python/tests/servers/test_stdio.py
@@ -1,0 +1,46 @@
+# setup GEVENT_SUPPORT
+import json
+import os
+
+os.environ["GEVENT_SUPPORT"] = "true"
+
+from dify_plugin.core.entities.plugin.io import PluginInStreamEvent
+from dify_plugin.core.server.stdio.request_reader import StdioRequestReader
+
+
+def test_stdio(monkeypatch):
+    payload = {
+        "session_id": "1",
+        "conversation_id": "2",
+        "message_id": "3",
+        "app_id": "4",
+        "endpoint_id": "5",
+        "data": {"test": "test" * 1000},
+        "event": PluginInStreamEvent.Request.value,
+    }
+
+    reader = StdioRequestReader()
+    dataflow_bytes = b"".join([json.dumps(payload).encode("utf-8") + b"\n" for _ in range(200)])
+    # split dataflow_bytes into 64KB chunks
+    dataflow_chunks = [dataflow_bytes[i : i + 65536] for i in range(0, len(dataflow_bytes), 65536)]
+
+    def mock_read_async():
+        return dataflow_chunks.pop(0)
+
+    # mock reader._read_async
+    monkeypatch.setattr(reader, "_read_async", mock_read_async)
+
+    iters = 0
+
+    for line in reader._read_stream():
+        assert line.event == PluginInStreamEvent.Request
+        assert line.session_id == "1"
+        assert line.conversation_id == "2"
+        assert line.message_id == "3"
+        assert line.app_id == "4"
+        assert line.endpoint_id == "5"
+        iters += 1
+        if iters == 200:
+            break
+
+    assert iters == 200

--- a/python/tests/servers/test_stdio.py
+++ b/python/tests/servers/test_stdio.py
@@ -1,4 +1,5 @@
 import json
+
 from dify_plugin.core.entities.plugin.io import PluginInStreamEvent
 from dify_plugin.core.server.stdio.request_reader import StdioRequestReader
 

--- a/python/tests/servers/test_stdio.py
+++ b/python/tests/servers/test_stdio.py
@@ -1,9 +1,4 @@
-# setup GEVENT_SUPPORT
 import json
-import os
-
-os.environ["GEVENT_SUPPORT"] = "true"
-
 from dify_plugin.core.entities.plugin.io import PluginInStreamEvent
 from dify_plugin.core.server.stdio.request_reader import StdioRequestReader
 


### PR DESCRIPTION
## Summary

This (probably) resolves the issues that had been widely reported regarding high CPU usage and increased processing times with multimodal input.

There's still probably room for further speed improvements, such as by changing how JSON serialization is handled, but for now, I'm submitting this PR to address the main cause.

## Related issues:

- https://github.com/langgenius/dify/issues/17799
- https://github.com/langgenius/dify/issues/19052
- closes https://github.com/langgenius/dify/issues/16441
- closes https://github.com/langgenius/dify-official-plugins/issues/757
- closes https://github.com/langgenius/dify-official-plugins/issues/779
- and more

## Detailed Description

There are mainly two major issues with the current implementation, both related to the `request_reader`:

- L24: It only receives up to 512 bytes at a time from standard input
- L32: It tries to `split` the `buffer` containing all data received so far

https://github.com/langgenius/dify-plugin-sdks/blob/a35cb4c5e6aaa3f6d419727a057b29a89300b534/python/dify_plugin/core/server/stdio/request_reader.py#L24-L32

Because of this, for example, if we attach a 5MB image, the following occurs:

- The `split` operation runs about **13,000 times**
  - 5 MB * 1.33 (base64 overhead) / 512 bytes
- For each `split`, processing is done on up to **6.7 MB of data**
  - Because `split` is for `buffer` instead of `data`

This PR makes the following changes:

- Increases the maximum read size from stdin to **64 KB** (x 128)
- Before running `split` against `buffer`, it first uses `find` on `data` (up to 64 KB); if it doesn’t find a match, it does nothing
- Only runs `split` against `buffer` when a `b"\n"` is found, and then proceeds with the rest of the processing

With these changes, the results are:

- Current: **`split` runs 13,000 times on up to 6.7 MB of data each time**
- With this PR: **`find` runs only 100 times on up to 64 KB of data, and there is only a single 6.7 MB `split`**


## Screenshots

Tested with attached DSL and large image on https://github.com/langgenius/dify-official-plugins/issues/648 by @Hzao (thanks for good assets👍)

**Current implementation**: **61s**
![03](https://github.com/user-attachments/assets/135c9ad5-ec63-4834-9a49-79ed06f070c1)
![image](https://github.com/user-attachments/assets/fd50cb1b-69a8-488b-82a8-1d802935e43d)

**With this PR**: **12s**
![04](https://github.com/user-attachments/assets/07dc5392-df08-4717-9975-1eac5c882c57)
![image](https://github.com/user-attachments/assets/f8e1b0cf-0546-46fb-9dc1-c790ff8f2e88)
