### PR TITLE
 chore: mark constructors as final in multiple classes

### DIFF
--- a/python/dify_plugin/interfaces/agent/__init__.py
+++ b/python/dify_plugin/interfaces/agent/__init__.py
@@ -1,7 +1,7 @@
 import logging
 from abc import abstractmethod
 from collections.abc import Generator, Mapping
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, final
 
 from pydantic import BaseModel, ConfigDict, Field, ValidationInfo, field_validator
 
@@ -149,11 +149,18 @@ class AgentProvider(ToolProvider):
 
 
 class AgentStrategy(ToolLike[AgentInvokeMessage]):
+    @final
     def __init__(
         self,
         runtime: AgentRuntime,
         session: Session,
     ):
+        """
+        Initialize the agent strategy
+
+        NOTE:
+        - This method has been marked as final, DO NOT OVERRIDE IT.
+        """
         self.runtime = runtime
         self.session = session
         self.response_type = AgentInvokeMessage

--- a/python/dify_plugin/interfaces/endpoint/__init__.py
+++ b/python/dify_plugin/interfaces/endpoint/__init__.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
+from typing import final
 
 from werkzeug import Request, Response
 
@@ -7,7 +8,14 @@ from dify_plugin.core.runtime import Session
 
 
 class Endpoint(ABC):
+    @final
     def __init__(self, session: Session) -> None:
+        """
+        Initialize the endpoint
+
+        NOTE:
+        - This method has been marked as final, DO NOT OVERRIDE IT.
+        """
         self.session = session
 
     ############################################################

--- a/python/dify_plugin/interfaces/model/ai_model.py
+++ b/python/dify_plugin/interfaces/model/ai_model.py
@@ -2,7 +2,7 @@ import decimal
 import socket
 from abc import ABC, abstractmethod
 from collections.abc import Mapping
-from typing import Optional
+from typing import Optional, final
 
 import gevent.socket
 from pydantic import ConfigDict
@@ -37,7 +37,14 @@ class AIModel(ABC):
     # pydantic configs
     model_config = ConfigDict(protected_namespaces=())
 
+    @final
     def __init__(self, model_schemas: list[AIModelEntity]) -> None:
+        """
+        Initialize the model
+
+        NOTE:
+        - This method has been marked as final, DO NOT OVERRIDE IT.
+        """
         self.model_schemas = [
             model_schema for model_schema in model_schemas if model_schema.model_type == self.model_type
         ]

--- a/python/dify_plugin/interfaces/tool/__init__.py
+++ b/python/dify_plugin/interfaces/tool/__init__.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from collections.abc import Generator, Mapping
-from typing import Any, Generic, Optional, TypeVar
+from typing import Any, Generic, Optional, TypeVar, final
 
 from dify_plugin.core.runtime import Session
 from dify_plugin.entities.agent import AgentInvokeMessage
@@ -235,11 +235,18 @@ class Tool(ToolLike[ToolInvokeMessage]):
     runtime: ToolRuntime
     session: Session
 
+    @final
     def __init__(
         self,
         runtime: ToolRuntime,
         session: Session,
     ):
+        """
+        Initialize the tool
+
+        NOTE:
+        - This method has been marked as final, DO NOT OVERRIDE IT.
+        """
         self.runtime = runtime
         self.session = session
         self.response_type = ToolInvokeMessage


### PR DESCRIPTION
- Added `@final` decorator to the constructors of `AgentStrategy`, `Endpoint`, `AIModel`, and `Tool` classes to prevent overriding.
- Included documentation notes in each constructor to indicate that they should not be overridden.