### PR TITLE
feat: support REMOTE_INSTALL_URL config for remote installing and debugging

### DIFF
--- a/python/dify_plugin/config/config.py
+++ b/python/dify_plugin/config/config.py
@@ -24,6 +24,7 @@ class DifyPluginEnv(BaseSettings):
         description="Installation method, local or network",
     )
 
+    REMOTE_INSTALL_URL: Optional[str] = Field( description="Remote installation URL")
     REMOTE_INSTALL_HOST: str = Field(default="localhost", description="Remote installation host")
     REMOTE_INSTALL_PORT: int = Field(default=5003, description="Remote installation port")
     REMOTE_INSTALL_KEY: Optional[str] = Field(default=None, description="Remote installation key")

--- a/python/dify_plugin/config/config.py
+++ b/python/dify_plugin/config/config.py
@@ -24,7 +24,7 @@ class DifyPluginEnv(BaseSettings):
         description="Installation method, local or network",
     )
 
-    REMOTE_INSTALL_URL: Optional[str] = Field( description="Remote installation URL")
+    REMOTE_INSTALL_URL: Optional[str] = Field(description="Remote installation URL")
     REMOTE_INSTALL_HOST: str = Field(default="localhost", description="Remote installation host")
     REMOTE_INSTALL_PORT: int = Field(default=5003, description="Remote installation port")
     REMOTE_INSTALL_KEY: Optional[str] = Field(default=None, description="Remote installation key")

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -95,8 +95,6 @@ class Plugin(IOServer, Router):
 
         return tcp_stream, tcp_stream
 
-
-
     def _initialize_tcp_stream(
         self,
         tcp_stream: TCPReaderWriter,

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -81,12 +81,12 @@ class Plugin(IOServer, Router):
         if not config.REMOTE_INSTALL_KEY:
             raise ValueError("Missing remote install key")
 
-        remote_install_host, remote_install_port = self._get_remote_install_host_and_port(config)
-        logging.debug(f"Remote installing to {remote_install_host}:{remote_install_port}")
+        install_host, install_port = self._get_remote_install_host_and_port(config)
+        logging.debug(f"Remote installing to {install_host}:{install_port}")
 
         tcp_stream = TCPReaderWriter(
-            remote_install_host,
-            remote_install_port,
+            install_host,
+            install_port,
             config.REMOTE_INSTALL_KEY,
             on_connected=lambda: self._initialize_tcp_stream(tcp_stream),
         )
@@ -390,6 +390,11 @@ class Plugin(IOServer, Router):
                 )
 
     def _get_remote_install_host_and_port(self, config: DifyPluginEnv) -> tuple[str, int]:
+        """
+        Get host and port for remote installation
+        :param config:  dify plugin env config
+        :return: host and port
+        """
         if config.REMOTE_INSTALL_URL:
             if ":" in config.REMOTE_INSTALL_URL:
                 split = config.REMOTE_INSTALL_URL.split(":")

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -93,8 +93,8 @@ class Plugin(IOServer, Router):
         logging.debug(f"Remote installing to {remote_install_host}:{remote_install_port}")
 
         tcp_stream = TCPReaderWriter(
-            config.REMOTE_INSTALL_HOST,
-            config.REMOTE_INSTALL_PORT,
+            remote_install_host,
+            remote_install_port,
             config.REMOTE_INSTALL_KEY,
             on_connected=lambda: self._initialize_tcp_stream(tcp_stream),
         )

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -93,8 +93,8 @@ class Plugin(IOServer, Router):
         logging.debug(f"Remote installing to {remote_install_host}:{remote_install_port}")
 
         tcp_stream = TCPReaderWriter(
-            remote_install_host,
-            remote_install_port,
+            config.REMOTE_INSTALL_HOST,
+            config.REMOTE_INSTALL_PORT,
             config.REMOTE_INSTALL_KEY,
             on_connected=lambda: self._initialize_tcp_stream(tcp_stream),
         )
@@ -156,7 +156,7 @@ class Plugin(IOServer, Router):
 
         for file in self.registration.files:
             # divide the file into chunks
-            chunks = [file.data[i: i + 8192] for i in range(0, len(file.data), 8192)]
+            chunks = [file.data[i : i + 8192] for i in range(0, len(file.data), 8192)]
             for sequence, chunk in enumerate(chunks):
                 tcp_stream.write(
                     InitializeMessage(
@@ -216,97 +216,97 @@ class Plugin(IOServer, Router):
         self.register_route(
             self.plugin_executer.invoke_tool,
             lambda data: data.get("type") == PluginInvokeType.Tool.value
-                         and data.get("action") == ToolActions.InvokeTool.value,
+            and data.get("action") == ToolActions.InvokeTool.value,
         )
 
         self.register_route(
             self.plugin_executer.validate_tool_provider_credentials,
             lambda data: data.get("type") == PluginInvokeType.Tool.value
-                         and data.get("action") == ToolActions.ValidateCredentials.value,
+            and data.get("action") == ToolActions.ValidateCredentials.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_agent_strategy,
             lambda data: data.get("type") == PluginInvokeType.Agent.value
-                         and data.get("action") == AgentActions.InvokeAgentStrategy.value,
+            and data.get("action") == AgentActions.InvokeAgentStrategy.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_llm,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.InvokeLLM.value,
+            and data.get("action") == ModelActions.InvokeLLM.value,
         )
 
         self.register_route(
             self.plugin_executer.get_llm_num_tokens,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.GetLLMNumTokens.value,
+            and data.get("action") == ModelActions.GetLLMNumTokens.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_text_embedding,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.InvokeTextEmbedding.value,
+            and data.get("action") == ModelActions.InvokeTextEmbedding.value,
         )
 
         self.register_route(
             self.plugin_executer.get_text_embedding_num_tokens,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.GetTextEmbeddingNumTokens.value,
+            and data.get("action") == ModelActions.GetTextEmbeddingNumTokens.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_rerank,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.InvokeRerank.value,
+            and data.get("action") == ModelActions.InvokeRerank.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_tts,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.InvokeTTS.value,
+            and data.get("action") == ModelActions.InvokeTTS.value,
         )
 
         self.register_route(
             self.plugin_executer.get_tts_model_voices,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.GetTTSVoices.value,
+            and data.get("action") == ModelActions.GetTTSVoices.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_speech_to_text,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.InvokeSpeech2Text.value,
+            and data.get("action") == ModelActions.InvokeSpeech2Text.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_moderation,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.InvokeModeration.value,
+            and data.get("action") == ModelActions.InvokeModeration.value,
         )
 
         self.register_route(
             self.plugin_executer.validate_model_provider_credentials,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.ValidateProviderCredentials.value,
+            and data.get("action") == ModelActions.ValidateProviderCredentials.value,
         )
 
         self.register_route(
             self.plugin_executer.validate_model_credentials,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.ValidateModelCredentials.value,
+            and data.get("action") == ModelActions.ValidateModelCredentials.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_endpoint,
             lambda data: data.get("type") == PluginInvokeType.Endpoint.value
-                         and data.get("action") == EndpointActions.InvokeEndpoint.value,
+            and data.get("action") == EndpointActions.InvokeEndpoint.value,
         )
 
         self.register_route(
             self.plugin_executer.get_ai_model_schemas,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-                         and data.get("action") == ModelActions.GetAIModelSchemas.value,
+            and data.get("action") == ModelActions.GetAIModelSchemas.value,
         )
 
     def _execute_request(
@@ -350,7 +350,7 @@ class Plugin(IOServer, Router):
                         blob = message.message.blob
                         message.message.blob = id_.encode("utf-8")
                         # split the blob into chunks
-                        chunks = [blob[i: i + 8192] for i in range(0, len(blob), 8192)]
+                        chunks = [blob[i : i + 8192] for i in range(0, len(blob), 8192)]
                         for sequence, chunk in enumerate(chunks):
                             writer.session_message(
                                 session_id=session_id,

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -398,7 +398,7 @@ class Plugin(IOServer, Router):
                 remote_install_host = split[0]
                 remote_install_port = int(split[1])
             else:
-                raise ValueError("Invalid remote install URL, should be in the format host:port")
+                raise ValueError("Invalid remote install URL, which should be in the format host:port")
         else:
             remote_install_host = config.REMOTE_INSTALL_HOST
             remote_install_port = config.REMOTE_INSTALL_PORT

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -81,16 +81,7 @@ class Plugin(IOServer, Router):
         if not config.REMOTE_INSTALL_KEY:
             raise ValueError("Missing remote install key")
 
-        if config.REMOTE_INSTALL_URL:
-            if ":" in config.REMOTE_INSTALL_URL:
-                split = config.REMOTE_INSTALL_URL.split(":")
-                remote_install_host = split[0]
-                remote_install_port = split[1]
-            else:
-                raise ValueError("Invalid remote install URL, should be in the format host:port")
-        else:
-            remote_install_host = config.REMOTE_INSTALL_HOST
-            remote_install_port = config.REMOTE_INSTALL_PORT
+        remote_install_host, remote_install_port = self._get_remote_install_host_and_port(config)
 
         logging.debug(f"Remote installing to {remote_install_host}:{remote_install_port}")
 
@@ -104,6 +95,8 @@ class Plugin(IOServer, Router):
         tcp_stream.launch()
 
         return tcp_stream, tcp_stream
+
+
 
     def _initialize_tcp_stream(
         self,
@@ -398,3 +391,17 @@ class Plugin(IOServer, Router):
                     session_id=session_id,
                     data=writer.stream_object(data=response),
                 )
+
+    def _get_remote_install_host_and_port(self, config: DifyPluginEnv) -> tuple[str, int]:
+        if config.REMOTE_INSTALL_URL:
+            if ":" in config.REMOTE_INSTALL_URL:
+                split = config.REMOTE_INSTALL_URL.split(":")
+                remote_install_host = split[0]
+                remote_install_port = int(split[1])
+            else:
+                raise ValueError("Invalid remote install URL, should be in the format host:port")
+        else:
+            remote_install_host = config.REMOTE_INSTALL_HOST
+            remote_install_port = config.REMOTE_INSTALL_PORT
+
+        return remote_install_host, remote_install_port

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -5,7 +5,6 @@ from collections.abc import Generator
 from typing import Any, Optional
 
 from pydantic import RootModel
-from yarl import URL
 
 from dify_plugin.config.config import DifyPluginEnv, InstallMethod
 from dify_plugin.config.logger_format import plugin_logger_handler
@@ -83,9 +82,12 @@ class Plugin(IOServer, Router):
             raise ValueError("Missing remote install key")
 
         if config.REMOTE_INSTALL_URL:
-            remote_install_url = URL(config.REMOTE_INSTALL_URL)
-            remote_install_host = remote_install_url.host
-            remote_install_port = remote_install_url.port
+            if ":" in config.REMOTE_INSTALL_URL:
+                split = config.REMOTE_INSTALL_URL.split(":")
+                remote_install_host = split[0]
+                remote_install_port = split[1]
+            else:
+                raise ValueError("Invalid remote install URL, should be in the format host:port")
         else:
             remote_install_host = config.REMOTE_INSTALL_HOST
             remote_install_port = config.REMOTE_INSTALL_PORT

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -394,23 +394,26 @@ class Plugin(IOServer, Router):
     def _get_remote_install_host_and_port(config: DifyPluginEnv) -> tuple[str, int]:
         """
         Get host and port for remote installation
-        :param config:  dify plugin env config
+        :param config: Dify plugin env config
         :return: host and port
         """
-        if config.REMOTE_INSTALL_URL:
-            if ":" in config.REMOTE_INSTALL_URL:
-                url = URL(config.REMOTE_INSTALL_URL)
+        install_url = config.REMOTE_INSTALL_URL
+        if install_url:
+            if ":" in install_url:
+                url = URL(install_url)
                 if url.host and url.port:
                     # for the url with protocol prefix
                     host = url.host
                     port = url.port
                 else:
                     # for "host:port" format
-                    split = config.REMOTE_INSTALL_URL.split(":")
+                    split = install_url.split(":")
                     host = split[0]
                     port = int(split[1])
             else:
-                raise ValueError("Invalid remote install URL, which should be in the format of host:port")
+                raise ValueError(
+                    f'Invalid remote install URL {install_url}, which should be in the format of "host:port"'
+                )
         else:
             host = config.REMOTE_INSTALL_HOST
             port = config.REMOTE_INSTALL_PORT

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -5,6 +5,7 @@ from collections.abc import Generator
 from typing import Any, Optional
 
 from pydantic import RootModel
+from yarl import URL
 
 from dify_plugin.config.config import DifyPluginEnv, InstallMethod
 from dify_plugin.config.logger_format import plugin_logger_handler
@@ -81,9 +82,19 @@ class Plugin(IOServer, Router):
         if not config.REMOTE_INSTALL_KEY:
             raise ValueError("Missing remote install key")
 
+        if config.REMOTE_INSTALL_URL and ":" in config.REMOTE_INSTALL_URL:
+            remote_install_url = URL(config.REMOTE_INSTALL_URL)
+            remote_install_host = remote_install_url.host
+            remote_install_port = remote_install_url.port
+        else:
+            remote_install_host = config.REMOTE_INSTALL_HOST
+            remote_install_port = config.REMOTE_INSTALL_PORT
+
+        logging.debug(f"Remote installing to {remote_install_host}:{remote_install_port}")
+
         tcp_stream = TCPReaderWriter(
-            config.REMOTE_INSTALL_HOST,
-            config.REMOTE_INSTALL_PORT,
+            remote_install_host,
+            remote_install_port,
             config.REMOTE_INSTALL_KEY,
             on_connected=lambda: self._initialize_tcp_stream(tcp_stream),
         )
@@ -145,7 +156,7 @@ class Plugin(IOServer, Router):
 
         for file in self.registration.files:
             # divide the file into chunks
-            chunks = [file.data[i : i + 8192] for i in range(0, len(file.data), 8192)]
+            chunks = [file.data[i: i + 8192] for i in range(0, len(file.data), 8192)]
             for sequence, chunk in enumerate(chunks):
                 tcp_stream.write(
                     InitializeMessage(
@@ -205,97 +216,97 @@ class Plugin(IOServer, Router):
         self.register_route(
             self.plugin_executer.invoke_tool,
             lambda data: data.get("type") == PluginInvokeType.Tool.value
-            and data.get("action") == ToolActions.InvokeTool.value,
+                         and data.get("action") == ToolActions.InvokeTool.value,
         )
 
         self.register_route(
             self.plugin_executer.validate_tool_provider_credentials,
             lambda data: data.get("type") == PluginInvokeType.Tool.value
-            and data.get("action") == ToolActions.ValidateCredentials.value,
+                         and data.get("action") == ToolActions.ValidateCredentials.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_agent_strategy,
             lambda data: data.get("type") == PluginInvokeType.Agent.value
-            and data.get("action") == AgentActions.InvokeAgentStrategy.value,
+                         and data.get("action") == AgentActions.InvokeAgentStrategy.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_llm,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.InvokeLLM.value,
+                         and data.get("action") == ModelActions.InvokeLLM.value,
         )
 
         self.register_route(
             self.plugin_executer.get_llm_num_tokens,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.GetLLMNumTokens.value,
+                         and data.get("action") == ModelActions.GetLLMNumTokens.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_text_embedding,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.InvokeTextEmbedding.value,
+                         and data.get("action") == ModelActions.InvokeTextEmbedding.value,
         )
 
         self.register_route(
             self.plugin_executer.get_text_embedding_num_tokens,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.GetTextEmbeddingNumTokens.value,
+                         and data.get("action") == ModelActions.GetTextEmbeddingNumTokens.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_rerank,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.InvokeRerank.value,
+                         and data.get("action") == ModelActions.InvokeRerank.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_tts,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.InvokeTTS.value,
+                         and data.get("action") == ModelActions.InvokeTTS.value,
         )
 
         self.register_route(
             self.plugin_executer.get_tts_model_voices,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.GetTTSVoices.value,
+                         and data.get("action") == ModelActions.GetTTSVoices.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_speech_to_text,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.InvokeSpeech2Text.value,
+                         and data.get("action") == ModelActions.InvokeSpeech2Text.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_moderation,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.InvokeModeration.value,
+                         and data.get("action") == ModelActions.InvokeModeration.value,
         )
 
         self.register_route(
             self.plugin_executer.validate_model_provider_credentials,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.ValidateProviderCredentials.value,
+                         and data.get("action") == ModelActions.ValidateProviderCredentials.value,
         )
 
         self.register_route(
             self.plugin_executer.validate_model_credentials,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.ValidateModelCredentials.value,
+                         and data.get("action") == ModelActions.ValidateModelCredentials.value,
         )
 
         self.register_route(
             self.plugin_executer.invoke_endpoint,
             lambda data: data.get("type") == PluginInvokeType.Endpoint.value
-            and data.get("action") == EndpointActions.InvokeEndpoint.value,
+                         and data.get("action") == EndpointActions.InvokeEndpoint.value,
         )
 
         self.register_route(
             self.plugin_executer.get_ai_model_schemas,
             lambda data: data.get("type") == PluginInvokeType.Model.value
-            and data.get("action") == ModelActions.GetAIModelSchemas.value,
+                         and data.get("action") == ModelActions.GetAIModelSchemas.value,
         )
 
     def _execute_request(
@@ -339,7 +350,7 @@ class Plugin(IOServer, Router):
                         blob = message.message.blob
                         message.message.blob = id_.encode("utf-8")
                         # split the blob into chunks
-                        chunks = [blob[i : i + 8192] for i in range(0, len(blob), 8192)]
+                        chunks = [blob[i: i + 8192] for i in range(0, len(blob), 8192)]
                         for sequence, chunk in enumerate(chunks):
                             writer.session_message(
                                 session_id=session_id,

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -82,7 +82,7 @@ class Plugin(IOServer, Router):
         if not config.REMOTE_INSTALL_KEY:
             raise ValueError("Missing remote install key")
 
-        if config.REMOTE_INSTALL_URL and ":" in config.REMOTE_INSTALL_URL:
+        if config.REMOTE_INSTALL_URL:
             remote_install_url = URL(config.REMOTE_INSTALL_URL)
             remote_install_host = remote_install_url.host
             remote_install_port = remote_install_url.port

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -82,7 +82,6 @@ class Plugin(IOServer, Router):
             raise ValueError("Missing remote install key")
 
         remote_install_host, remote_install_port = self._get_remote_install_host_and_port(config)
-
         logging.debug(f"Remote installing to {remote_install_host}:{remote_install_port}")
 
         tcp_stream = TCPReaderWriter(


### PR DESCRIPTION
- Currently, we have to manually separate the URL from the page into host and port fields.
- It's handy to support REMOTE_INSTALL_URL copied in the plugin SDK.

<img width="310" alt="image" src="https://github.com/user-attachments/assets/cf18b574-7224-482d-8379-7549f2ab8521" />
