### PR TITLE
feat[0.6.0](endpoint): add support for endpoint group setup

### DIFF
--- a/python/dify_plugin/core/entities/plugin/request.py
+++ b/python/dify_plugin/core/entities/plugin/request.py
@@ -221,7 +221,7 @@ class EndpointSetupRequest(BaseModel):
     type: PluginInvokeType = PluginInvokeType.Endpoint
     action: EndpointActions = EndpointActions.SetupEndpoint
     endpoint_group: str = Field(default="default", description="The endpoint group name")
-    credentials: Mapping
+    settings: Mapping
 
 
 class EndpointInvokeRequest(BaseModel):

--- a/python/dify_plugin/core/entities/plugin/request.py
+++ b/python/dify_plugin/core/entities/plugin/request.py
@@ -49,7 +49,7 @@ class ModelActions(Enum):
 
 
 class EndpointActions(Enum):
-    Setup = "setup"
+    SetupEndpoint = "setup_endpoint"
     InvokeEndpoint = "invoke_endpoint"
 
 
@@ -219,7 +219,7 @@ class ModelGetAIModelSchemas(PluginAccessModelRequest):
 
 class EndpointSetupRequest(BaseModel):
     type: PluginInvokeType = PluginInvokeType.Endpoint
-    action: EndpointActions = EndpointActions.Setup
+    action: EndpointActions = EndpointActions.SetupEndpoint
     endpoint_group: str = Field(default="default", description="The endpoint group name")
     credentials: Mapping
 

--- a/python/dify_plugin/core/entities/plugin/request.py
+++ b/python/dify_plugin/core/entities/plugin/request.py
@@ -1,7 +1,8 @@
+from collections.abc import Mapping
 from enum import Enum
 from typing import Any, Optional
 
-from pydantic import BaseModel, ConfigDict, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from dify_plugin.entities.model import ModelType
 from dify_plugin.entities.model.message import (
@@ -48,6 +49,7 @@ class ModelActions(Enum):
 
 
 class EndpointActions(Enum):
+    Setup = "setup"
     InvokeEndpoint = "invoke_endpoint"
 
 
@@ -215,8 +217,15 @@ class ModelGetAIModelSchemas(PluginAccessModelRequest):
     action: ModelActions = ModelActions.GetAIModelSchemas
 
 
+class EndpointSetupRequest(BaseModel):
+    type: PluginInvokeType = PluginInvokeType.Endpoint
+    action: EndpointActions = EndpointActions.Setup
+    endpoint_group: str = Field(default="default", description="The endpoint group name")
+    credentials: Mapping
+
+
 class EndpointInvokeRequest(BaseModel):
     type: PluginInvokeType = PluginInvokeType.Endpoint
     action: EndpointActions = EndpointActions.InvokeEndpoint
-    settings: dict
+    settings: Mapping
     raw_http_request: str

--- a/python/dify_plugin/core/plugin_executor.py
+++ b/python/dify_plugin/core/plugin_executor.py
@@ -8,6 +8,7 @@ from dify_plugin.config.config import DifyPluginEnv
 from dify_plugin.core.entities.plugin.request import (
     AgentInvokeRequest,
     EndpointInvokeRequest,
+    EndpointSetupRequest,
     ModelGetAIModelSchemas,
     ModelGetLLMNumTokens,
     ModelGetTextEmbeddingNumTokens,
@@ -273,6 +274,13 @@ class PluginExecutor:
             }
         else:
             raise ValueError(f"Model `{data.model_type}` not found for provider `{data.provider}`")
+
+    def setup_endpoint_group(self, session: Session, data: EndpointSetupRequest):
+        endpoint_group_cls = self.registration.get_endpoint_group_cls(data.endpoint_group)
+        if endpoint_group_cls is None:
+            raise ValueError(f"Endpoint group `{data.endpoint_group}` not found")
+
+        endpoint_group_cls().setup(data.credentials)
 
     def invoke_endpoint(self, session: Session, data: EndpointInvokeRequest):
         bytes_data = binascii.unhexlify(data.raw_http_request)

--- a/python/dify_plugin/core/plugin_executor.py
+++ b/python/dify_plugin/core/plugin_executor.py
@@ -280,7 +280,7 @@ class PluginExecutor:
         if endpoint_group_cls is None:
             raise ValueError(f"Endpoint group `{data.endpoint_group}` not found")
 
-        endpoint_group_cls().setup(data.credentials)
+        endpoint_group_cls().setup(data.settings)
 
     def invoke_endpoint(self, session: Session, data: EndpointInvokeRequest):
         bytes_data = binascii.unhexlify(data.raw_http_request)

--- a/python/dify_plugin/core/plugin_registration.py
+++ b/python/dify_plugin/core/plugin_registration.py
@@ -75,6 +75,7 @@ class PluginRegistration:
         self.tools_mapping = {}
         self.models_mapping = {}
         self.endpoints_configuration = []
+        self.endpoint_groups = []
         self.endpoints = Map()
         self.files = []
         self.agent_strategies_configuration = []

--- a/python/dify_plugin/core/server/serverless/request_reader.py
+++ b/python/dify_plugin/core/server/serverless/request_reader.py
@@ -3,8 +3,6 @@ import time
 from collections.abc import Generator
 from queue import Empty, Queue
 
-from flask import Flask, request
-
 from dify_plugin.core.entities.plugin.io import (
     PluginInStream,
     PluginInStreamEvent,
@@ -27,6 +25,8 @@ class ServerlessRequestReader(RequestReader):
         """
         Initialize the ServerlessStream and wait for jobs
         """
+        from flask import Flask
+
         super().__init__()
         self.app = Flask(__name__)
         self.host = host
@@ -46,6 +46,8 @@ class ServerlessRequestReader(RequestReader):
             yield self.request_queue.get()
 
     def handler(self):
+        from flask import request
+
         try:
             queue = Queue[str]()
             data = request.get_json()

--- a/python/dify_plugin/entities/endpoint.py
+++ b/python/dify_plugin/entities/endpoint.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from pydantic import BaseModel, Field, field_validator
 
 from dify_plugin.core.documentation.schema_doc import docs
@@ -28,6 +30,17 @@ class EndpointConfiguration(BaseModel):
 
 
 @docs(
+    name="EndpointGroupExtra",
+    description="The extra of the endpoint group",
+)
+class EndpointGroupConfigurationExtra(BaseModel):
+    class Python(BaseModel):
+        source: str
+
+    python: Python
+
+
+@docs(
     name="EndpointGroup",
     description="The Manifest of the endpoint group",
     outside_reference_fields={"endpoints": EndpointConfiguration},
@@ -35,6 +48,15 @@ class EndpointConfiguration(BaseModel):
 class EndpointProviderConfiguration(BaseModel):
     settings: list[ProviderConfig] = Field(default_factory=list)
     endpoints: list[EndpointConfiguration] = Field(default_factory=list)
+    custom_initialize_process_enabled: bool = Field(
+        default=False,
+        description="Whether enable custom initialize process, "
+        "please ensure `extra` is not None and `python.source` is set",
+    )
+    extra: Optional[EndpointGroupConfigurationExtra] = Field(
+        default=None,
+        description="The extra of the endpoint group",
+    )
 
     @classmethod
     def _load_yaml_file(cls, path: str) -> dict:

--- a/python/dify_plugin/errors/endpoint.py
+++ b/python/dify_plugin/errors/endpoint.py
@@ -1,0 +1,16 @@
+from typing import Optional
+
+
+class EndpointSetupFailedError(Exception):
+    """
+    The error that occurs when the endpoint setup failed
+    """
+
+    description: Optional[str] = None
+
+    def __init__(self, description: Optional[str] = None) -> None:
+        if description:
+            self.description = description
+
+    def __str__(self):
+        return self.description or self.__class__.__name__

--- a/python/dify_plugin/interfaces/endpoint/__init__.py
+++ b/python/dify_plugin/interfaces/endpoint/__init__.py
@@ -8,11 +8,11 @@ from dify_plugin.core.runtime import Session
 
 
 class EndpointGroup(ABC):
-    def setup(self, credentials: Mapping):
-        return self._setup(credentials)
+    def setup(self, settings: Mapping):
+        return self._setup(settings)
 
     @abstractmethod
-    def _setup(self, credentials: Mapping):
+    def _setup(self, settings: Mapping):
         pass
 
 

--- a/python/dify_plugin/interfaces/endpoint/__init__.py
+++ b/python/dify_plugin/interfaces/endpoint/__init__.py
@@ -7,6 +7,15 @@ from werkzeug import Request, Response
 from dify_plugin.core.runtime import Session
 
 
+class EndpointGroup(ABC):
+    def setup(self, credentials: Mapping):
+        return self._setup(credentials)
+
+    @abstractmethod
+    def _setup(self, credentials: Mapping):
+        pass
+
+
 class Endpoint(ABC):
     @final
     def __init__(self, session: Session) -> None:

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -293,6 +293,12 @@ class Plugin(IOServer, Router):
         )
 
         self.register_route(
+            self.plugin_executer.setup_endpoint_group,
+            lambda data: data.get("type") == PluginInvokeType.Endpoint.value
+            and data.get("action") == EndpointActions.Setup.value,
+        )
+
+        self.register_route(
             self.plugin_executer.get_ai_model_schemas,
             lambda data: data.get("type") == PluginInvokeType.Model.value
             and data.get("action") == ModelActions.GetAIModelSchemas.value,

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -295,7 +295,7 @@ class Plugin(IOServer, Router):
         self.register_route(
             self.plugin_executer.setup_endpoint_group,
             lambda data: data.get("type") == PluginInvokeType.Endpoint.value
-            and data.get("action") == EndpointActions.Setup.value,
+            and data.get("action") == EndpointActions.SetupEndpoint.value,
         )
 
         self.register_route(


### PR DESCRIPTION
- Introduced `setup_endpoint_group` method in `PluginExecutor` to handle endpoint group initialization.
- Added `EndpointSetupRequest` model to facilitate setup requests with credentials and endpoint group information.
- Enhanced `PluginRegistration` to load endpoint groups from configuration and retrieve them by name.
- Updated `Plugin` class to register a new route for handling setup actions.
- Modified existing endpoint-related classes to support the new endpoint group functionality.