### PR TITLE
fix REMOTE_INSTALL_URL, need default value

### DIFF
--- a/python/dify_plugin/config/config.py
+++ b/python/dify_plugin/config/config.py
@@ -24,7 +24,7 @@ class DifyPluginEnv(BaseSettings):
         description="Installation method, local or network",
     )
 
-    REMOTE_INSTALL_URL: Optional[str] = Field(description="Remote installation URL")
+    REMOTE_INSTALL_URL: Optional[str] = Field(default=None, description="Remote installation URL")
     REMOTE_INSTALL_HOST: str = Field(default="localhost", description="Remote installation host")
     REMOTE_INSTALL_PORT: int = Field(default=5003, description="Remote installation port")
     REMOTE_INSTALL_KEY: Optional[str] = Field(default=None, description="Remote installation key")

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -398,7 +398,7 @@ class Plugin(IOServer, Router):
         :return: host and port
         """
         install_url = config.REMOTE_INSTALL_URL
-        if install_url:
+        if install_url is not None:
             if ":" in install_url:
                 url = URL(install_url)
                 if url.host and url.port:


### PR DESCRIPTION
version0.2.3 incompatibility problem

fixes:  #140

`REMOTE_INSTALL_URL` need a default None 