### PR TITLE
feat: add filename support to multi-modal prompt messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ For the manifest specification, we've introduced two versioning fields:
 | 1.5.1                | 0.4.0         | Support LLM structured output           |
 | 1.6.0                | 0.4.1         | Support `dark-icon` field in manifest |
 | 1.7.0                | 0.4.2         | Support OAuth functionality for plugins |
+| 1.8.1                | 0.4.3         | Support filename in MultiModalPromptMessageContent |

--- a/python/dify_plugin/entities/model/message.py
+++ b/python/dify_plugin/entities/model/message.py
@@ -83,6 +83,7 @@ class MultiModalPromptMessageContent(PromptMessageContent):
     base64_data: str = Field(default="", description="the base64 data of multi-modal file")
     url: str = Field(default="", description="the url of multi-modal file")
     mime_type: str = Field(default=..., description="the mime type of multi-modal file")
+    filename: str = Field(default="", description="the filename of multi-modal file")
 
     @property
     def data(self):


### PR DESCRIPTION
## Summary

This PR adds filename support to multi-modal prompt messages by introducing a `filename` field to the `MultiModalPromptMessageContent` class. This change aligns the SDK with the main Dify repository implementation (PR langgenius/dify#24777).

### Changes
- Added `filename` field (default: empty string) to `MultiModalPromptMessageContent` class in `python/dify_plugin/entities/model/message.py`
- The filename field is optional and defaults to an empty string for backward compatibility
- Inherited by all multi-modal content types (Image, Video, Audio, Document)

### Testing
- Verified field is properly added to the class
- Confirmed backward compatibility with default empty string value

Closes #196

## Pull Request Checklist

### Compatibility Check

- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [ ] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [ ] I have checked whether the plugin version is updated in the `README.md`

**Compatibility Impact**: This change is fully backward compatible. The new `filename` field defaults to an empty string, so existing code will continue to work without modification.

### Available Checks

- [x] Code has passed local tests
- [x] Relevant documentation has been updated (if necessary) - Field includes proper description

🤖 Generated with [Claude Code](https://claude.ai/code)