### PR TITLE
feat(python): relaxing version verification

### DIFF
--- a/python/dify_plugin/core/entities/plugin/setup.py
+++ b/python/dify_plugin/core/entities/plugin/setup.py
@@ -1,7 +1,9 @@
 import datetime
 from enum import Enum
+from typing import Optional
 
-from pydantic import BaseModel, Field
+from packaging.version import InvalidVersion, Version
+from pydantic import BaseModel, Field, field_validator
 
 from dify_plugin.core.documentation.schema_doc import docs
 from dify_plugin.entities import I18nObject
@@ -147,10 +149,20 @@ class PluginConfiguration(BaseModel):
             description="The minimum version of Dify, designed for forward compatibility."
             "When installing a newer plugin to an older Dify, many new features may not be available,"
             "but showing the minimum Dify version helps users understand how to upgrade.",
-            pattern=r"^\d{1,4}(\.\d{1,4}){1,3}(-\w{1,16})?$",
         )
 
-    version: str = Field(..., pattern=r"^\d{1,4}(\.\d{1,4}){1,3}(-\w{1,16})?$")
+        @field_validator("minimum_dify_version")
+        @classmethod
+        def validate_minimum_dify_version(cls, v: Optional[str]) -> Optional[str]:
+            if v is None:
+                return v
+            try:
+                Version(v)
+                return v
+            except InvalidVersion as e:
+                raise ValueError(f"Invalid version format: {v}") from e
+
+    version: str = Field(...)
     type: PluginType
     author: str | None = Field(..., pattern=r"^[a-zA-Z0-9_-]{1,64}$")
     name: str = Field(..., pattern=r"^[a-z0-9_-]{1,128}$")
@@ -163,6 +175,15 @@ class PluginConfiguration(BaseModel):
     resource: PluginResourceRequirements
     plugins: Plugins
     meta: Meta
+
+    @field_validator("version")
+    @classmethod
+    def validate_version(cls, v: str) -> str:
+        try:
+            Version(v)
+            return v
+        except InvalidVersion as e:
+            raise ValueError(f"Invalid version format: {v}") from e
 
 
 @docs(


### PR DESCRIPTION
Relaxing the verification for `PluginConfiguration.version` and `PluginConfiguration.Meta.minimum_dify_version`.

SDK part of langgenius/dify#25160

# Pull Request Checklist

Thank you for your contribution! Before submitting your PR, please make sure you have completed the following checks:

## Compatibility Check

- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [x] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [x] I have checked whether the plugin version is updated in the `README.md`

## Available Checks

- [ ] Code has passed local tests
- [x] Relevant documentation has been updated (if necessary)
