### PR TITLE
fix(openai_compatible): omit rerank authorization without an API key

### DIFF
--- a/src/dify_plugin/interfaces/model/openai_compatible/rerank.py
+++ b/src/dify_plugin/interfaces/model/openai_compatible/rerank.py
@@ -66,10 +66,9 @@ class OAICompatRerankModel(RerankModel):
             raise CredentialsValidateFailedError(msg)
 
         url = server_url
-        headers = {
-            "Authorization": f"Bearer {credentials.get('api_key')}",
-            "Content-Type": "application/json",
-        }
+        headers = {"Content-Type": "application/json"}
+        if api_key := credentials.get("api_key"):
+            headers["Authorization"] = f"Bearer {api_key}"
 
         # Open question: truncate docs before llama.cpp-compatible requests?
 

--- a/tests/interfaces/model/openai_compatible/test_rerank.py
+++ b/tests/interfaces/model/openai_compatible/test_rerank.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dify_plugin.interfaces.model.openai_compatible.rerank import (
+    OAICompatRerankModel,
+)
+
+
+@pytest.mark.parametrize(
+    ("credentials", "expected_headers"),
+    [
+        (
+            {"endpoint_url": "https://example.com/v1"},
+            {"Content-Type": "application/json"},
+        ),
+        (
+            {"endpoint_url": "https://example.com/v1", "api_key": None},
+            {"Content-Type": "application/json"},
+        ),
+        (
+            {"endpoint_url": "https://example.com/v1", "api_key": ""},
+            {"Content-Type": "application/json"},
+        ),
+        (
+            {"endpoint_url": "https://example.com/v1", "api_key": str(123)},
+            {
+                "Authorization": "Bearer 123",
+                "Content-Type": "application/json",
+            },
+        ),
+    ],
+)
+def test_invoke_only_sends_authorization_with_api_key(
+    credentials: dict, expected_headers: dict[str, str]
+) -> None:
+    response = MagicMock()
+    response.json.return_value = {"results": [{"index": 0, "relevance_score": 1.0}]}
+
+    with patch(
+        "dify_plugin.interfaces.model.openai_compatible.rerank.post",
+        return_value=response,
+    ) as post:
+        OAICompatRerankModel([]).invoke(
+            model="model",
+            credentials=credentials,
+            query="query",
+            docs=["document"],
+        )
+
+    assert post.call_args.kwargs["headers"] == expected_headers


### PR DESCRIPTION
Related to https://github.com/langgenius/dify-official-plugins/issues/1724

## Summary

Omit the `Authorization` header from OpenAI-compatible rerank requests when `api_key` is missing or empty.

The current implementation sends `Bearer None` or an empty Bearer value, which causes gateways for unauthenticated rerank endpoints to reject otherwise valid requests.

## Root cause

`OAICompatRerankModel._invoke` constructs the Bearer header unconditionally.

The same method is used by both model invocation and credential validation, so fixing it there covers both paths.

## Changes

- Build the required `Content-Type` header first.
- Add `Authorization` only when `api_key` is non-empty.
- Add a focused regression test for missing, empty, and non-empty API keys.

## Compatibility

Non-empty API keys produce the same header as before.

Missing, `None`, and empty keys no longer produce malformed authentication headers.

The request URL, body, timeout, response parsing, and score normalization are unchanged.

No dependency, schema, manifest, or public API changes are introduced.

## Scope

This PR fixes the shared SDK `OAICompatRerankModel`.

The current official `openai_api_compatible` plugin overrides this method and requires a separate follow-up.

The related issue should remain open until that override is fixed as well.

## Test plan

- [x] `uv run pytest tests/interfaces/model/openai_compatible/test_rerank.py tests/interfaces/model/test_rerank.py`
- [x] `just check`
- [x] `just test`
