### PR TITLE
fix(openai_compatible): serialize video prompt content

### DIFF
--- a/src/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/src/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -43,6 +43,7 @@ from dify_plugin.entities.model.message import (
     SystemPromptMessage,
     ToolPromptMessage,
     UserPromptMessage,
+    VideoPromptMessageContent,
 )
 from dify_plugin.errors.model import CredentialsValidateFailedError, InvokeError
 from dify_plugin.interfaces.model.large_language_model import LargeLanguageModel
@@ -964,6 +965,15 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                             },
                         }
                         sub_messages.append(sub_message_dict)
+                    elif message_content.type == PromptMessageContentType.VIDEO:
+                        message_content = cast(
+                            "VideoPromptMessageContent",
+                            message_content,
+                        )
+                        sub_messages.append({
+                            "type": "video_url",
+                            "video_url": {"url": message_content.data},
+                        })
 
                 message_dict = {"role": "user", "content": sub_messages}
         elif isinstance(message, AssistantPromptMessage):

--- a/tests/interfaces/model/openai_compatible/test_llm.py
+++ b/tests/interfaces/model/openai_compatible/test_llm.py
@@ -7,6 +7,11 @@ from unittest.mock import MagicMock, PropertyMock, patch
 import pytest
 
 from dify_plugin.entities.model.llm import LLMResultChunk
+from dify_plugin.entities.model.message import (
+    TextPromptMessageContent,
+    UserPromptMessage,
+    VideoPromptMessageContent,
+)
 from dify_plugin.errors.model import CredentialsValidateFailedError
 from dify_plugin.interfaces.model.openai_compatible.llm import (
     OAICompatLargeLanguageModel,
@@ -87,6 +92,47 @@ def test_validate_credentials_passes_extra_headers(
     assert post.call_args.kwargs.get("stream", False) is stream
     assert post.call_args.kwargs["json"]["max_tokens"] == max_tokens
     response.close.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("video_kwargs", "expected_url"),
+    [
+        (
+            {"url": "https://example.com/video.mp4"},
+            "https://example.com/video.mp4",
+        ),
+        ({"base64_data": "AAAA"}, "data:video/mp4;base64,AAAA"),
+    ],
+)
+def test_convert_prompt_message_to_dict_serializes_video(
+    video_kwargs: dict[str, str],
+    expected_url: str,
+) -> None:
+    video = VideoPromptMessageContent(
+        format="mp4",
+        mime_type="video/mp4",
+        **video_kwargs,
+    )
+
+    result = OAICompatLargeLanguageModel([])._convert_prompt_message_to_dict(
+        UserPromptMessage(
+            content=[
+                TextPromptMessageContent(data="Describe the video"),
+                video,
+            ]
+        )
+    )
+
+    assert result == {
+        "role": "user",
+        "content": [
+            {"type": "text", "text": "Describe the video"},
+            {
+                "type": "video_url",
+                "video_url": {"url": expected_url},
+            },
+        ],
+    }
 
 
 @pytest.mark.parametrize("extra_headers", [False, "", [], [("X-Api-Key", "value")]])


### PR DESCRIPTION
Closes #254

## Summary

Serialize `VideoPromptMessageContent` in requests made by the shared OpenAI-compatible LLM.

The SDK already advertises `ModelFeature.VIDEO` when `video_support` is enabled, but the shared serializer currently drops video blocks.

## Root cause

`OAICompatLargeLanguageModel._convert_prompt_message_to_dict` handles text and image content but has no branch for video content.

The existing `VideoPromptMessageContent.data` property already returns either the remote URL or a complete base64 data URL.

## Changes

- Serialize video blocks as `type: video_url`.
- Place the existing media URL in `video_url.url`.
- Add focused coverage for remote and base64 video content alongside text.

## Compatibility

This change only affects requests containing video content.

Text, image, tool, assistant, system, and function messages remain unchanged.

No dependency, schema, manifest, public API, or version changes are introduced.

Endpoints that do not support the `video_url` extension should leave `video_support` disabled.

## Scope

This pull request fixes the shared SDK serializer.

The official OpenAI API-compatible plugin currently overrides this method and is outside this pull request.

Audio, document, frame extraction, upload, and endpoint-specific media formats remain unchanged.

## Test plan

- [x] `uv run pytest tests/interfaces/model/openai_compatible/test_llm.py -k video`
- [x] `just check`
- [x] `just test`
