### PR TITLE
Add comments and unit tests for trigger factory

### DIFF
--- a/python/dify_plugin/core/trigger_factory.py
+++ b/python/dify_plugin/core/trigger_factory.py
@@ -1,1 +1,168 @@
-# TBD: Codex, need to implement this, refer to model_factory.py
+from __future__ import annotations
+
+"""Utilities for registering trigger providers and retrieving runtime classes."""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from dify_plugin.core.runtime import Session
+from dify_plugin.entities.trigger import (
+    TriggerConfiguration,
+    TriggerProviderConfiguration,
+    TriggerSubscriptionConstructorRuntime,
+)
+from dify_plugin.interfaces.trigger import TriggerEvent, TriggerProvider, TriggerSubscriptionConstructor
+
+
+@dataclass(slots=True)
+class _TriggerProviderEntry:
+    """Internal container storing metadata associated with a trigger provider."""
+
+    configuration: TriggerProviderConfiguration
+    provider_cls: type[TriggerProvider]
+    subscription_constructor_cls: type[TriggerSubscriptionConstructor] | None
+    triggers: dict[str, tuple[TriggerConfiguration, type[TriggerEvent]]]
+
+
+class TriggerProviderRegistration:
+    """Helper that allows incremental registration of provider triggers."""
+
+    def __init__(self, entry: _TriggerProviderEntry) -> None:
+        self._entry = entry
+
+    def register_trigger(
+        self,
+        *,
+        name: str,
+        configuration: TriggerConfiguration,
+        trigger_cls: type[TriggerEvent],
+    ) -> None:
+        """Register a trigger implementation for the provider."""
+
+        if name in self._entry.triggers:
+            raise ValueError(
+                f"Trigger `{name}` is already registered for provider `{self._entry.configuration.identity.name}`"
+            )
+
+        self._entry.triggers[name] = (configuration, trigger_cls)
+
+
+class TriggerFactory:
+    """Registry that produces trigger related runtime instances on demand."""
+
+    def __init__(self) -> None:
+        # Provider name -> runtime metadata. Using a dict allows O(1) lookups when
+        # resolving provider classes during request handling.
+        self._providers: dict[str, _TriggerProviderEntry] = {}
+
+    def register_trigger_provider(
+        self,
+        *,
+        configuration: TriggerProviderConfiguration,
+        provider_cls: type[TriggerProvider],
+        subscription_constructor_cls: type[TriggerSubscriptionConstructor] | None,
+        triggers: Mapping[str, tuple[TriggerConfiguration, type[TriggerEvent]]],
+    ) -> TriggerProviderRegistration:
+        """Register a trigger provider and its runtime classes."""
+
+        # Each provider can only be registered once to avoid conflicting runtime
+        # definitions when multiple plugins try to use the same identifier.
+        provider_name = configuration.identity.name
+        if provider_name in self._providers:
+            raise ValueError(f"Trigger provider `{provider_name}` is already registered")
+
+        entry = _TriggerProviderEntry(
+            configuration=configuration,
+            provider_cls=provider_cls,
+            subscription_constructor_cls=subscription_constructor_cls,
+            triggers={},
+        )
+
+        self._providers[provider_name] = entry
+
+        registration = TriggerProviderRegistration(entry)
+        # Pre-populate the registry with triggers that were already discovered
+        # during plugin loading. Providers can keep adding more triggers by
+        # calling ``registration.register_trigger`` inside their module level
+        # registration hook.
+        for name, (trigger_config, trigger_cls) in triggers.items():
+            registration.register_trigger(
+                name=name,
+                configuration=trigger_config,
+                trigger_cls=trigger_cls,
+            )
+
+        return registration
+
+    # ------------------------------------------------------------------
+    # Provider factories
+    # ------------------------------------------------------------------
+    def get_trigger_provider(self, provider_name: str, session: Session) -> TriggerProvider:
+        """Instantiate the trigger provider implementation for the given provider name."""
+
+        entry = self._get_entry(provider_name)
+        return entry.provider_cls(session)
+
+    def get_provider_cls(self, provider_name: str) -> type[TriggerProvider]:
+        return self._get_entry(provider_name).provider_cls
+
+    def has_subscription_constructor(self, provider_name: str) -> bool:
+        return self._get_entry(provider_name).subscription_constructor_cls is not None
+
+    def get_subscription_constructor(
+        self,
+        provider_name: str,
+        runtime: TriggerSubscriptionConstructorRuntime,
+        session: Session,
+    ) -> TriggerSubscriptionConstructor:
+        """Instantiate the subscription constructor implementation."""
+
+        entry = self._get_entry(provider_name)
+        if not entry.subscription_constructor_cls:
+            raise ValueError(f"Trigger provider `{provider_name}` does not define a subscription constructor")
+
+        return entry.subscription_constructor_cls(runtime, session)
+
+    def get_subscription_constructor_cls(
+        self, provider_name: str
+    ) -> type[TriggerSubscriptionConstructor] | None:
+        return self._get_entry(provider_name).subscription_constructor_cls
+
+    # ------------------------------------------------------------------
+    # Trigger event factories
+    # ------------------------------------------------------------------
+    def get_trigger_event_handler(self, provider_name: str, event: str, session: Session) -> TriggerEvent:
+        """Instantiate a trigger event handler for the given provider and event name."""
+
+        entry = self._get_entry(provider_name)
+        if event not in entry.triggers:
+            raise ValueError(f"Trigger `{event}` not found in provider `{provider_name}`")
+
+        _, trigger_cls = entry.triggers[event]
+        return trigger_cls(session)
+
+    def get_trigger_configuration(
+        self, provider_name: str, event: str
+    ) -> TriggerConfiguration | None:
+        entry = self._get_entry(provider_name)
+        trigger = entry.triggers.get(event)
+        if trigger is None:
+            return None
+        return trigger[0]
+
+    def iter_triggers(self, provider_name: str) -> Mapping[str, tuple[TriggerConfiguration, type[TriggerEvent]]]:
+        """Return a shallow copy of the registered triggers for inspection."""
+
+        # Returning a copy ensures callers cannot mutate the internal registry
+        # inadvertently, while still providing a dictionary-like interface for
+        # tooling and API handlers that need to enumerate triggers.
+        return dict(self._get_entry(provider_name).triggers)
+
+    def get_configuration(self, provider_name: str) -> TriggerProviderConfiguration:
+        return self._get_entry(provider_name).configuration
+
+    def _get_entry(self, provider_name: str) -> _TriggerProviderEntry:
+        try:
+            return self._providers[provider_name]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise ValueError(f"Trigger provider `{provider_name}` not found") from exc

--- a/python/tests/core/test_trigger_factory.py
+++ b/python/tests/core/test_trigger_factory.py
@@ -1,0 +1,262 @@
+"""Tests for the trigger factory runtime registry."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+import sys
+import types
+
+import pytest
+from werkzeug import Request
+
+PROJECT_ROOT = Path(__file__).resolve().parents[3]
+PYTHON_SRC = PROJECT_ROOT / "python"
+
+for candidate in (str(PROJECT_ROOT), str(PYTHON_SRC)):
+    if candidate not in sys.path:
+        sys.path.insert(0, candidate)
+
+# Avoid importing the top-level ``dify_plugin`` package which performs heavy
+# initialisation (including gevent monkey patching) that is unnecessary for
+# unit tests. Instead we register a lightweight namespace package that points
+# at the source directory so submodules can be imported normally.
+if "dify_plugin" not in sys.modules:
+    dify_plugin_pkg = types.ModuleType("dify_plugin")
+    dify_plugin_pkg.__path__ = [str(PYTHON_SRC / "dify_plugin")]
+    sys.modules["dify_plugin"] = dify_plugin_pkg
+
+from dify_plugin.core.trigger_factory import TriggerFactory
+from dify_plugin.entities import I18nObject
+from dify_plugin.entities.trigger import (
+    Event,
+    Subscription,
+    SubscriptionSchema,
+    TriggerConfiguration,
+    TriggerConfigurationExtra,
+    TriggerDescription,
+    TriggerIdentity,
+    TriggerProviderConfiguration,
+    TriggerProviderConfigurationExtra,
+    TriggerProviderIdentity,
+    TriggerSubscriptionConstructorConfiguration,
+    TriggerSubscriptionConstructorConfigurationExtra,
+    TriggerSubscriptionConstructorRuntime,
+    UnsubscribeResult,
+)
+from dify_plugin.interfaces.trigger import TriggerEvent, TriggerProvider, TriggerSubscriptionConstructor
+
+
+class DummyProvider(TriggerProvider):
+    """Minimal provider implementation used for factory tests."""
+
+    def _dispatch_event(self, subscription: Subscription, request: Request):  # pragma: no cover - unused in tests
+        raise NotImplementedError
+
+
+class DummyConstructor(TriggerSubscriptionConstructor):
+    """Minimal constructor implementation for instantiation tests."""
+
+    def _validate_api_key(self, credentials: dict):  # pragma: no cover - unused in tests
+        return None
+
+    def _create_subscription(
+        self,
+        endpoint: str,
+        credentials: Mapping[str, object],
+        selected_events: list[str],
+        parameters: Mapping[str, object],
+    ) -> Subscription:  # pragma: no cover - unused in tests
+        return Subscription(
+            expires_at=0,
+            endpoint=endpoint,
+            parameters={},
+            properties={},
+        )
+
+    def _delete_subscription(
+        self, subscription: Subscription, credentials: Mapping[str, object]
+    ) -> UnsubscribeResult:  # pragma: no cover - unused in tests
+        return UnsubscribeResult(success=True)
+
+    def _refresh(
+        self, subscription: Subscription, credentials: Mapping[str, object]
+    ) -> Subscription:  # pragma: no cover - unused in tests
+        return subscription
+
+
+class DummyTrigger(TriggerEvent):
+    """Simple trigger that captures the injected session."""
+
+    def _trigger(self, request: Request, parameters: Mapping[str, object]) -> Event:
+        return Event(variables={})
+
+
+@pytest.fixture
+def trigger_configuration() -> TriggerConfiguration:
+    return TriggerConfiguration(
+        identity=TriggerIdentity(
+            author="unit",
+            name="dummy-event",
+            label=I18nObject(en_US="Dummy Event"),
+        ),
+        parameters=[],
+        description=TriggerDescription(
+            human=I18nObject(en_US="Human description"),
+            llm=I18nObject(en_US="LLM description"),
+        ),
+        extra=TriggerConfigurationExtra(
+            python=TriggerConfigurationExtra.Python(source="dummy_trigger.py"),
+        ),
+        output_schema=None,
+    )
+
+
+@pytest.fixture
+def provider_configuration() -> TriggerProviderConfiguration:
+    return TriggerProviderConfiguration(
+        identity=TriggerProviderIdentity(
+            author="unit",
+            name="dummy-provider",
+            label=I18nObject(en_US="Dummy Provider"),
+            description=I18nObject(en_US="Dummy description"),
+        ),
+        credentials_schema=[],
+        oauth_schema=None,
+        subscription_schema=SubscriptionSchema(),
+        subscription_constructor=TriggerSubscriptionConstructorConfiguration(
+            parameters=[],
+            credentials_schema=[],
+            oauth_schema=None,
+            extra=TriggerSubscriptionConstructorConfigurationExtra(
+                python=TriggerSubscriptionConstructorConfigurationExtra.Python(
+                    source="dummy_constructor.py"
+                ),
+            ),
+        ),
+        triggers=[],
+        extra=TriggerProviderConfigurationExtra(
+            python=TriggerProviderConfigurationExtra.Python(source="dummy_provider.py"),
+        ),
+    )
+
+
+def test_register_trigger_provider_and_accessors(
+    provider_configuration: TriggerProviderConfiguration,
+    trigger_configuration: TriggerConfiguration,
+) -> None:
+    factory = TriggerFactory()
+
+    factory.register_trigger_provider(
+        configuration=provider_configuration,
+        provider_cls=DummyProvider,
+        subscription_constructor_cls=DummyConstructor,
+        triggers={"dummy-event": (trigger_configuration, DummyTrigger)},
+    )
+
+    session = object()
+    provider = factory.get_trigger_provider("dummy-provider", session)
+    assert isinstance(provider, DummyProvider)
+    assert provider.session is session
+
+    assert factory.has_subscription_constructor("dummy-provider") is True
+
+    runtime = TriggerSubscriptionConstructorRuntime(credentials={}, session_id="session")
+    constructor = factory.get_subscription_constructor("dummy-provider", runtime, session)
+    assert isinstance(constructor, DummyConstructor)
+    assert constructor.runtime is runtime
+
+    handler = factory.get_trigger_event_handler("dummy-provider", "dummy-event", session)
+    assert isinstance(handler, DummyTrigger)
+    assert handler.session is session
+
+    config = factory.get_trigger_configuration("dummy-provider", "dummy-event")
+    assert config is trigger_configuration
+
+    assert dict(factory.iter_triggers("dummy-provider")) == {"dummy-event": (trigger_configuration, DummyTrigger)}
+
+
+def test_register_trigger_provider_prevents_duplicate_names(
+    provider_configuration: TriggerProviderConfiguration,
+    trigger_configuration: TriggerConfiguration,
+) -> None:
+    factory = TriggerFactory()
+
+    factory.register_trigger_provider(
+        configuration=provider_configuration,
+        provider_cls=DummyProvider,
+        subscription_constructor_cls=None,
+        triggers={"dummy-event": (trigger_configuration, DummyTrigger)},
+    )
+
+    with pytest.raises(ValueError):
+        factory.register_trigger_provider(
+            configuration=provider_configuration,
+            provider_cls=DummyProvider,
+            subscription_constructor_cls=None,
+            triggers={},
+        )
+
+
+def test_registration_helper_prevents_duplicate_trigger_names(
+    provider_configuration: TriggerProviderConfiguration,
+    trigger_configuration: TriggerConfiguration,
+) -> None:
+    factory = TriggerFactory()
+
+    registration = factory.register_trigger_provider(
+        configuration=provider_configuration,
+        provider_cls=DummyProvider,
+        subscription_constructor_cls=None,
+        triggers={"dummy-event": (trigger_configuration, DummyTrigger)},
+    )
+
+    with pytest.raises(ValueError):
+        registration.register_trigger(
+            name="dummy-event",
+            configuration=trigger_configuration,
+            trigger_cls=DummyTrigger,
+        )
+
+
+def test_iter_triggers_returns_copy(
+    provider_configuration: TriggerProviderConfiguration,
+    trigger_configuration: TriggerConfiguration,
+) -> None:
+    factory = TriggerFactory()
+    factory.register_trigger_provider(
+        configuration=provider_configuration,
+        provider_cls=DummyProvider,
+        subscription_constructor_cls=None,
+        triggers={"dummy-event": (trigger_configuration, DummyTrigger)},
+    )
+
+    triggers = factory.iter_triggers("dummy-provider")
+    assert triggers == {"dummy-event": (trigger_configuration, DummyTrigger)}
+
+    # Mutating the returned mapping must not affect the factory's internal state.
+    triggers["dummy-event"] = (trigger_configuration, DummyTrigger)
+    assert factory.iter_triggers("dummy-provider") == {"dummy-event": (trigger_configuration, DummyTrigger)}
+
+
+def test_get_trigger_event_handler_unknown_event(
+    provider_configuration: TriggerProviderConfiguration,
+    trigger_configuration: TriggerConfiguration,
+) -> None:
+    factory = TriggerFactory()
+    factory.register_trigger_provider(
+        configuration=provider_configuration,
+        provider_cls=DummyProvider,
+        subscription_constructor_cls=None,
+        triggers={"dummy-event": (trigger_configuration, DummyTrigger)},
+    )
+
+    with pytest.raises(ValueError):
+        factory.get_trigger_event_handler("dummy-provider", "missing", object())
+
+
+def test_get_entry_unknown_provider_raises() -> None:
+    factory = TriggerFactory()
+
+    with pytest.raises(ValueError):
+        factory.get_trigger_provider("missing", object())


### PR DESCRIPTION
## Summary
- document the trigger factory registry to give contributors more context when registering providers
- add a dedicated unit test module that verifies provider, constructor, and trigger handling logic

## Testing
- pytest python/tests/core/test_trigger_factory.py

------
https://chatgpt.com/codex/tasks/task_b_68d6a2c86328832684f70fb76351713b