### PR TITLE
fix: unclosed <think> tag when content is empty

### DIFF
--- a/python/dify_plugin/interfaces/model/large_language_model.py
+++ b/python/dify_plugin/interfaces/model/large_language_model.py
@@ -543,7 +543,7 @@ if you are not sure about the structure.
                 is_reasoning = True
             else:
                 content = reasoning_content
-        elif is_reasoning and content:
+        elif is_reasoning:
             content = "\n</think>" + content
             is_reasoning = False
         return content, is_reasoning


### PR DESCRIPTION
- fix unclosed <think> tag when content is empty (tool_calls or others)
- see the same reported issue https://github.com/langgenius/dify/issues/25482
