### PR TITLE
Draft: Alternative Normalization Scheme for Reranking Update rerank.py

### DIFF
--- a/python/dify_plugin/interfaces/model/openai_compatible/rerank.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/rerank.py
@@ -77,10 +77,11 @@ class OAICompatRerankModel(RerankModel):
             rerank_documents = []
             scores = [result["relevance_score"] for result in results["results"]]
 
-            # Min-Max Normalization: Normalize scores to 0 ~ 1.0 range
-            min_score = min(scores)
-            max_score = max(scores)
-            score_range = max_score - min_score if max_score != min_score else 1.0  # Avoid division by zero
+            # Use sigmoid normalization to map scores to 0-1 range
+            import math
+            def sigmoid(x):
+                # Apply the sigmoid formula: 1 / (1 + e^(-x))
+                return 1.0 / (1.0 + math.exp(-x))
 
             for result in results["results"]:
                 index = result["index"]
@@ -94,8 +95,8 @@ class OAICompatRerankModel(RerankModel):
                     elif isinstance(document, str):
                         text = document
 
-                # Normalize the score
-                normalized_score = (result["relevance_score"] - min_score) / score_range
+                # Normalize the score Apply sigmoid normalization to each score
+                normalized_scores = [sigmoid(score) for score in scores]
 
                 # Create RerankDocument object with normalized score
                 rerank_document = RerankDocument(


### PR DESCRIPTION
# Draft: Alternative Normalization Scheme for Reranking

This submission presents a draft of a normalization scheme more suitable for reranking tasks. 

Notably, this implementation replaces the original Min-Max normalization (which maps scores to the 0~1.0 range) with sigmoid normalization. The sigmoid function (1 / (1 + e^(-x))) is applied to each score to achieve the 0-1 range mapping.

Important note: This change will have a significant impact on API numerical values that currently return results in the (0,1) range. Therefore, this draft is not recommended for merging at this stage.

# Pull Request Checklist

Thank you for your contribution! Before submitting your PR, please make sure you have completed the following checks:

## Compatibility Check

- [ ] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [ ] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [ ] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [ ] I have described the compatibility impact and the corresponding version number in the PR description
- [ ] I have checked whether the plugin version is updated in the `README.md`

## Available Checks

- [ ] Code has passed local tests
- [ ] Relevant documentation has been updated (if necessary)
