### PR TITLE
feat: add reasoning_content field to LLMResultChunkDelta

### DIFF
--- a/python/dify_plugin/entities/model/llm.py
+++ b/python/dify_plugin/entities/model/llm.py
@@ -76,6 +76,7 @@ class LLMResultChunkDelta(BaseModel):
 
     index: int
     message: AssistantPromptMessage
+    reasoning_content: str | None = None
     usage: LLMUsage | None = None
     finish_reason: str | None = None
 


### PR DESCRIPTION
## Summary
Add optional `reasoning_content` field to `LLMResultChunkDelta` for structured streaming of LLM reasoning/thinking processes.

**Relates to** #227 (issue)
**Follow-up to** langgenius/dify#23313
## Changes
```python
class LLMResultChunkDelta(BaseModel):
    index: int
    message: AssistantPromptMessage
    reasoning_content: str | None = None  # ← NEW
    usage: LLMUsage | None = None
    finish_reason: str | None = None
```

## Why
Currently, plugins merge reasoning into `message.content` with `<think>` tags, requiring Main to parse them back out. This adds:
- A dedicated field for reasoning content
- Enables cleaner separation between reasoning and final response
- Eliminates fragile tag-based parsing

## Compatibility
- [x] **Backward-compatible**: Optional field (default `None`), no breaking changes for existing plugins.

## Next Steps
This is **Phase 1(SDK)** of a multi-repo rollout:
- Phase 2 (Plugins): Add defensive `pop("_dify_supports_reasoning_content", False)` in all LLM plugins to prevent vendor API errors when Main sends capability flags
- Phase 3 (Main): Read `reasoning_content` from plugins and use `delta.reasoning_content` directly if present (with fallback to `_split_reasoning()`), then send capability flag via `model_parameters` for plugin optimization.

- Phase 4 (Plugins): Provider-by-provider opt-in to emit `reasoning_content` deltas

See #227 for full plan.




- Add optional reasoning_content field to support direct streaming of LLM reasoning/thinking content, separate from the main message content.

# Pull Request Checklist

Thank you for your contribution! Before submitting your PR, please make sure you have completed the following checks:

## Compatibility Check

- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [x] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [x] I have checked whether the plugin version is updated in the `README.md`

## Available Checks

- [x] Code has passed local tests
- [x] Relevant documentation has been updated (if necessary)
