### PR TITLE
feat: (sdk/python): add passthrough parameter (extends langgenius/dify#27078)

### DIFF
--- a/python/dify_plugin/core/entities/plugin/io.py
+++ b/python/dify_plugin/core/entities/plugin/io.py
@@ -30,6 +30,7 @@ class PluginInStreamBase:
         app_id: str | None = None,
         endpoint_id: str | None = None,
         context: dict | None = None,
+        passthrough: str | None = None,
     ) -> None:
         self.session_id = session_id
         self.event = event
@@ -39,6 +40,7 @@ class PluginInStreamBase:
         self.app_id = app_id
         self.endpoint_id = endpoint_id
         self.context = context
+        self.passthrough = passthrough
 
 
 class PluginInStream(PluginInStreamBase):
@@ -54,7 +56,18 @@ class PluginInStream(PluginInStreamBase):
         app_id: str | None = None,
         endpoint_id: str | None = None,
         context: dict | None = None,
+        passthrough: str | None = None,
     ):
         self.reader = reader
         self.writer = writer
-        super().__init__(session_id, event, data, conversation_id, message_id, app_id, endpoint_id, context)
+        super().__init__(
+            session_id,
+            event,
+            data,
+            conversation_id,
+            message_id,
+            app_id,
+            endpoint_id,
+            context,
+            passthrough,
+        )

--- a/python/dify_plugin/core/plugin_executor.py
+++ b/python/dify_plugin/core/plugin_executor.py
@@ -89,8 +89,8 @@ class PluginExecutor:
             session=session,
         )
 
-        # invoke tool
-        yield from tool.invoke(request.tool_parameters)
+        # invoke tool with passthrough (if provided)
+        yield from tool.invoke(request.tool_parameters, passthrough=session.passthrough)
 
     def invoke_agent_strategy(self, session: Session, request: AgentInvokeRequest):
         agent_cls = self.registration.get_agent_strategy_cls(request.agent_strategy_provider, request.agent_strategy)

--- a/python/dify_plugin/core/runtime.py
+++ b/python/dify_plugin/core/runtime.py
@@ -120,6 +120,7 @@ class Session:
         app_id: str | None = None,
         endpoint_id: str | None = None,
         context: SessionContext | dict | None = None,
+        passthrough: str | None = None,
         max_invocation_timeout: int = 250,
     ) -> None:
         # current session id
@@ -151,6 +152,9 @@ class Session:
         self.context: SessionContext = (
             SessionContext.model_validate(context) if isinstance(context, dict) else context or SessionContext()
         )
+
+        # passthrough data from Dify
+        self.passthrough: str | None = passthrough
 
         # dify plugin daemon url
         self.dify_plugin_daemon_url: str | None = dify_plugin_daemon_url

--- a/python/dify_plugin/core/server/io_server.py
+++ b/python/dify_plugin/core/server/io_server.py
@@ -47,6 +47,7 @@ class IOServer(ABC):
         app_id: str | None = None,
         endpoint_id: str | None = None,
         context: dict | None = None,
+        passthrough: str | None = None,
     ):
         """
         accept requests and execute them, should be implemented outside
@@ -72,6 +73,7 @@ class IOServer(ABC):
                 data.app_id,
                 data.endpoint_id,
                 data.context,
+                data.passthrough,
             )
 
     def _execute_request_in_thread(
@@ -85,6 +87,7 @@ class IOServer(ABC):
         app_id: str | None = None,
         endpoint_id: str | None = None,
         context: dict | None = None,
+        passthrough: str | None = None,
     ):
         """
         wrapper for _execute_request
@@ -101,6 +104,7 @@ class IOServer(ABC):
                 app_id,
                 endpoint_id,
                 context,
+                passthrough,
             )
         except Exception as e:
             args = {}

--- a/python/dify_plugin/core/server/serverless/request_reader.py
+++ b/python/dify_plugin/core/server/serverless/request_reader.py
@@ -59,6 +59,7 @@ class ServerlessRequestReader(RequestReader):
                 endpoint_id=data.get("endpoint_id"),
                 data=data["data"],
                 context=data.get("context"),
+                passthrough=data.get("passthrough"),
                 reader=self,
                 writer=ServerlessResponseWriter(queue),
             )

--- a/python/dify_plugin/core/server/stdio/request_reader.py
+++ b/python/dify_plugin/core/server/stdio/request_reader.py
@@ -68,6 +68,7 @@ class StdioRequestReader(RequestReader):
                         event=PluginInStreamEvent.value_of(data["event"]),
                         data=data["data"],
                         context=data.get("context"),
+                        passthrough=data.get("passthrough"),
                         reader=self,
                         writer=StdioResponseWriter(),
                     )

--- a/python/dify_plugin/core/server/tcp/request_reader.py
+++ b/python/dify_plugin/core/server/tcp/request_reader.py
@@ -199,6 +199,7 @@ class TCPReaderWriter(RequestReader, ResponseWriter):
                         event=PluginInStreamEvent.value_of(data["event"]),
                         data=data["data"],
                         context=data.get("context"),
+                        passthrough=data.get("passthrough"),
                         reader=self,
                         writer=self,
                     )

--- a/python/dify_plugin/interfaces/tool/__init__.py
+++ b/python/dify_plugin/interfaces/tool/__init__.py
@@ -357,10 +357,14 @@ class Tool(ToolLike[ToolInvokeMessage]):
     #                 For executor use only                    #
     ############################################################
 
-    def invoke(self, tool_parameters: dict) -> Generator[ToolInvokeMessage, None, None]:
+    def invoke(self, tool_parameters: dict, passthrough: str | None = None) -> Generator[ToolInvokeMessage, None, None]:
         # convert parameters into correct types
         tool_parameters = self._convert_parameters(tool_parameters)
-        return self._invoke(tool_parameters)
+        # try to pass passthrough to implementations that support it, fallback otherwise
+        try:
+            return self._invoke(tool_parameters, passthrough=passthrough)  # type: ignore[call-arg]
+        except TypeError:
+            return self._invoke(tool_parameters)
 
     @deprecated("This feature is deprecated, will soon be replaced by dynamic select parameter")
     def get_runtime_parameters(self) -> list[ToolParameter]:

--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -385,6 +385,7 @@ class Plugin(IOServer, Router):
         app_id: str | None = None,
         endpoint_id: str | None = None,
         context: dict | None = None,
+        passthrough: str | None = None,
     ):
         """
         accept requests and execute
@@ -404,6 +405,7 @@ class Plugin(IOServer, Router):
             app_id=app_id,
             endpoint_id=endpoint_id,
             context=context,
+            passthrough=passthrough,
             max_invocation_timeout=self.config.MAX_INVOCATION_TIMEOUT,
         )
         response = self.dispatch(session, data)


### PR DESCRIPTION
  - Context
      - This PR extends langgenius/dify#27078 by adding passthrough parameter support to the Python plugin
        SDK, aligning with EAM-specific behavior so downstream users don’t need a custom SDK.
  - Changes
      - Add Session.passthrough and propagate via stdio/TCP/serverless readers.
      - Extend PluginInStream to carry passthrough.
      - Wire passthrough through IOServer/Plugin into Session.
      - Forward session.passthrough to Tool.invoke in PluginExecutor.
      - Backward-compatible Tool.invoke: prefer _invoke(..., passthrough=...), fallback on TypeError.
  - Compatibility
      - Backward compatible: existing tools without passthrough are unaffected.
      - No breaking changes to public APIs.
  - Related
      - Extends langgenius/dify#27078