### PR TITLE
feat: Configurable Ping Max Tokens

### DIFF
--- a/python/dify_plugin/config/config.py
+++ b/python/dify_plugin/config/config.py
@@ -40,6 +40,11 @@ class DifyPluginEnv(BaseSettings):
 
     DIFY_PLUGIN_DAEMON_URL: str = Field(default="http://localhost:5002", description="backwards invocation address")
 
+    PING_MAX_TOKENS: int = Field(
+        default=16,
+        description="Maximum tokens for model validation ping request. Some providers require at least 16 tokens.",
+    )
+
     model_config = SettingsConfigDict(
         # read from dotenv format config file
         env_file=".env",


### PR DESCRIPTION
# Feature: Configurable Ping Max Tokens

## Overview

Changed the `max_tokens` parameter in OpenAI-compatible model validation (ping) requests from a hard-coded value to an environment variable-based configuration, improving flexibility and meeting different provider requirements.

## Background

Some OpenAI-compatible model providers—such as OpenRouter (when wrapping other vendors or offering models like gpt-5-codex)—either require the max_tokens parameter in validation requests to be at least 16 (resulting in validation failure if not met) or enforce a minimum output token limit overall (returning a 400 error for very small values like 5). However, the previous implementation hard-coded this max_tokens value as 5, which lacked flexibility.
<img width="1014" height="955" alt="image" src="https://github.com/user-attachments/assets/1ecb10ce-1182-49b4-b38f-507652a70ce2" />

Fixes #225 
## Changes

### 1. Configuration File Changes

**File:** `python/dify_plugin/config/config.py`

Added a new environment variable configuration in the `DifyPluginEnv` class:

```python
PING_MAX_TOKENS: int = Field(
    default=16,
    description="Maximum tokens for model validation ping request. Some providers require at least 16 tokens.",
)
```

**Notes:**
- Default value set to 16, meeting the minimum requirement for most providers
- Can be customized via the `.env` file
- Clear naming with detailed description

### 2. Implementation Code Changes

**File:** `python/dify_plugin/interfaces/model/openai_compatible/llm.py`

#### 2.1 Import Configuration Class

Added at the beginning of the file:

```python
from dify_plugin.config.config import DifyPluginEnv
```

#### 2.2 Modified validate_credentials Method

In the `validate_credentials` method:

1. Added configuration reading logic:
```python
# Load ping max tokens from environment variable
config = DifyPluginEnv()
ping_max_tokens = config.PING_MAX_TOKENS
```

2. Replaced hard-coded max_tokens value:
```python
# Before
data = {"model": credentials.get("endpoint_model_name", model), "max_tokens": 5}

# After
data = {"model": credentials.get("endpoint_model_name", model), "max_tokens": ping_max_tokens}
```

3. Also fixed the hard-coded value in stream mode:
```python
# Before
if stream_mode_auth == "use":
    data["stream"] = True
    data["max_tokens"] = 10

# After
if stream_mode_auth == "use":
    data["stream"] = True
    data["max_tokens"] = ping_max_tokens
```

## Usage

### 1. Using Default Value (Recommended)

No configuration needed. The system will use the default value of 16.

### 2. Custom Configuration

Add to the `.env` file in the project root directory:

```bash
PING_MAX_TOKENS=32
```

Or set other values based on actual needs, for example:

```bash
# Some special providers may require larger values
PING_MAX_TOKENS=64
```

## Compatibility Notes

- **Backward Compatible**: Changes are fully backward compatible and do not affect existing functionality
- **Default Behavior Change**: Default value changed from 5 to 16, meeting minimum requirements for most providers
- **Flexible Configuration**: Supports customization via environment variables for different scenarios

## Related Files

- `python/dify_plugin/config/config.py` - Configuration definition
- `python/dify_plugin/interfaces/model/openai_compatible/llm.py` - Implementation code

## Modification Date

2025-01-06


# Pull Request Checklist

Thank you for your contribution! Before submitting your PR, please make sure you have completed the following checks:

## Compatibility Check

- [✔] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [✔] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [✔] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [✔] I have described the compatibility impact and the corresponding version number in the PR description
- [✔] I have checked whether the plugin version is updated in the `README.md`

## Available Checks

- [✔] Code has passed local tests
- [✔] Relevant documentation has been updated (if necessary)
