### PR TITLE
Upgrade sdk version

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -20,5 +20,5 @@ When depending on this SDK, it's recommended to specify version constraints that
 Example in your project's dependency management:
 
 ```python
-dify_plugin>=0.3.0,<0.5.0
+dify_plugin>=0.6.0,<0.7.0
 ```

--- a/python/examples/agent/requirements.txt
+++ b/python/examples/agent/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin>=0.4.2
+dify_plugin==0.6.2

--- a/python/examples/dropbox_trigger/requirements.txt
+++ b/python/examples/dropbox_trigger/requirements.txt
@@ -1,2 +1,2 @@
-dify_plugin==0.6.0b14
+dify_plugin==0.6.2
 requests>=2.31.0

--- a/python/examples/firecrawl_datasource/requirements.txt
+++ b/python/examples/firecrawl_datasource/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin==0.5.0
+dify_plugin==0.6.2

--- a/python/examples/github/requirements.txt
+++ b/python/examples/github/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin==0.6.0b10
+dify_plugin==0.6.2

--- a/python/examples/github_trigger/requirements.txt
+++ b/python/examples/github_trigger/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin==0.6.0b14
+dify_plugin==0.6.2

--- a/python/examples/gmail_trigger/requirements.txt
+++ b/python/examples/gmail_trigger/requirements.txt
@@ -1,3 +1,3 @@
-dify_plugin==0.6.0b14
+dify_plugin==0.6.2
 google-auth>=2.0.0
 google-cloud-pubsub>=2.20.0

--- a/python/examples/google/requirements.txt
+++ b/python/examples/google/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin~=0.0.1b22
+dify_plugin==0.6.2

--- a/python/examples/google_calendar_trigger/requirements.txt
+++ b/python/examples/google_calendar_trigger/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.31.0
-dify_plugin==0.6.0b14
+dify_plugin==0.6.2

--- a/python/examples/google_cloud_storage/requirements.txt
+++ b/python/examples/google_cloud_storage/requirements.txt
@@ -1,2 +1,2 @@
-dify_plugin==0.5.0
+dify_plugin==0.6.2
 google-cloud-storage

--- a/python/examples/google_drive_trigger/requirements.txt
+++ b/python/examples/google_drive_trigger/requirements.txt
@@ -1,2 +1,2 @@
 requests>=2.31.0
-dify_plugin==0.6.0b14
+dify_plugin==0.6.2

--- a/python/examples/jina/requirements.txt
+++ b/python/examples/jina/requirements.txt
@@ -1,2 +1,2 @@
-dify_plugin~=0.0.1b31
+dify_plugin==0.6.2
 transformers~=4.42.4

--- a/python/examples/lark_trigger/requirements.txt
+++ b/python/examples/lark_trigger/requirements.txt
@@ -1,3 +1,3 @@
-dify_plugin==0.6.0b14
+dify_plugin==0.6.2
 lark-oapi==1.4.23
 cachetools==6.2.1

--- a/python/examples/neko/requirements.txt
+++ b/python/examples/neko/requirements.txt
@@ -1,2 +1,2 @@
-dify_plugin~=0.0.1b22
+dify_plugin==0.6.2
 flask~=3.0.3

--- a/python/examples/notion_datasource/requirements.txt
+++ b/python/examples/notion_datasource/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin==0.5.0
+dify_plugin==0.6.2

--- a/python/examples/openai/requirements.txt
+++ b/python/examples/openai/requirements.txt
@@ -1,4 +1,4 @@
-dify_plugin~=0.0.1b31
+dify_plugin==0.6.2
 tiktoken~=0.8.0
 openai~=1.45.0
 numpy~=1.26.4

--- a/python/examples/slack_trigger/requirements.txt
+++ b/python/examples/slack_trigger/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin==0.6.0b14
+dify_plugin==0.6.2

--- a/python/examples/telegram_trigger/requirements.txt
+++ b/python/examples/telegram_trigger/requirements.txt
@@ -1,1 +1,1 @@
-dify_plugin==0.6.0b14
+dify_plugin==0.6.2

--- a/python/uv.lock
+++ b/python/uv.lock
@@ -145,7 +145,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.6.0b9"
+version = "0.6.2"
 source = { editable = "." }
 dependencies = [
     { name = "dpkt" },


### PR DESCRIPTION
# Pull Request Checklist

Thank you for your contribution! Before submitting your PR, please make sure you have completed the following checks:

## Compatibility Check

- [ ] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [ ] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [ ] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [x] I have checked whether the plugin version is updated in the `README.md`

## Available Checks

- [ ] Code has passed local tests
- [x] Relevant documentation has been updated (if necessary)

---

This PR upgrades the `dify_plugin` SDK version to `0.6.2` across all example projects and updates the recommended version constraint in the `README.md`.

**Why this change?**
To align all example dependencies and documentation with the latest stable SDK release (`0.6.2`), eliminating inconsistencies from mixed beta and legacy versions.

**What was changed?**
- Pinned `dify_plugin` to `==0.6.2` in all `python/examples/**/requirements.txt` files.
- Updated the recommended version constraint in `python/README.md` to `dify_plugin>=0.6.0,<0.7.0`.
- Synced the `dify-plugin` version in `python/uv.lock` to `0.6.2`.

**Compatibility Impact:**
This upgrade moves examples from various older versions (including `0.0.1bXX`, `0.4.2`, `0.5.0`, `0.6.0bXX`) to `0.6.2`. While this ensures consistency with the latest stable SDK, it may introduce breaking changes for examples relying on APIs that have changed or been removed between their previous version and `0.6.2`. No code changes were made to adapt examples to potential API changes.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7c30e44-8e7c-4a6b-b61f-1322c3ebbd0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a7c30e44-8e7c-4a6b-b61f-1322c3ebbd0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

