### PR TITLE
fix: miss max_single_connection_lifetime

### DIFF
--- a/python/dify_plugin/plugin.py
+++ b/python/dify_plugin/plugin.py
@@ -200,12 +200,13 @@ class Plugin(IOServer, Router):
         Launch Serverless stream
         """
         serverless = ServerlessRequestReader(
-            config.SERVERLESS_HOST,
-            config.SERVERLESS_PORT,
-            config.SERVERLESS_WORKER_CLASS,
-            config.SERVERLESS_WORKERS,
-            config.SERVERLESS_THREADS,
-            config.MAX_REQUEST_TIMEOUT,
+            host=config.SERVERLESS_HOST,
+            port=config.SERVERLESS_PORT,
+            worker_class=config.SERVERLESS_WORKER_CLASS,
+            workers=config.SERVERLESS_WORKERS,
+            worker_connections=config.SERVERLESS_WORKER_CONNECTIONS,
+            threads=config.SERVERLESS_THREADS,
+            max_single_connection_lifetime=config.MAX_REQUEST_TIMEOUT,
         )
         serverless.launch()
 


### PR DESCRIPTION
# Pull Request Checklist

The maximum execution time has exceeded 300, and the parameter `max_single_connection_lifetime` is omitted in the original code

<img width="1554" height="888" alt="CleanShot 2025-11-25 at 17 28 22@2x" src="https://github.com/user-attachments/assets/4807480f-22c7-4cdf-a7bd-cc623c5f90ad" />



## Compatibility Check

- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [x] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [x] I have checked whether the plugin version is updated in the `README.md`

## Available Checks

- [x] Code has passed local tests
- [x] Relevant documentation has been updated (if necessary)
