### PR TITLE
fix(model): preserve dark provider icons

### DIFF
--- a/src/dify_plugin/entities/model/provider.py
+++ b/src/dify_plugin/entities/model/provider.py
@@ -200,6 +200,8 @@ class ProviderEntity(BaseModel):
     description: I18nObject | None = None
     icon_small: I18nObject | None = None
     icon_large: I18nObject | None = None
+    icon_small_dark: I18nObject | None = None
+    icon_large_dark: I18nObject | None = None
     background: str | None = None
     help: ProviderHelpEntity | None = None
     supported_model_types: Sequence[ModelType]
@@ -226,6 +228,8 @@ class ProviderEntity(BaseModel):
             label=self.label,
             icon_small=self.icon_small,
             icon_large=self.icon_large,
+            icon_small_dark=self.icon_small_dark,
+            icon_large_dark=self.icon_large_dark,
             supported_model_types=self.supported_model_types,
             models=self.models,
         )

--- a/tests/interfaces/model/test_construct_model_provider.py
+++ b/tests/interfaces/model/test_construct_model_provider.py
@@ -7,6 +7,24 @@ from dify_plugin.entities.model.provider import ProviderEntity
 from dify_plugin.interfaces.model import ModelProvider
 
 
+def test_provider_dark_icons_are_preserved() -> None:
+    icon_small_dark = I18nObject(en_us="small-dark.svg")
+    icon_large_dark = I18nObject(en_us="large-dark.svg")
+    provider = ProviderEntity(
+        provider="test",
+        label=I18nObject(en_us="test"),
+        icon_small_dark=icon_small_dark,
+        icon_large_dark=icon_large_dark,
+        supported_model_types=[ModelType.LLM],
+        configurate_methods=[],
+    )
+
+    simple_provider = provider.to_simple_provider()
+
+    assert simple_provider.icon_small_dark == icon_small_dark
+    assert simple_provider.icon_large_dark == icon_large_dark
+
+
 def test_construct_model_provider() -> None:
     """
     Ensure ModelProvider constructor is intact and usable.


### PR DESCRIPTION
## Summary

- Preserve `icon_small_dark` and `icon_large_dark` when loading model provider declarations.
- Forward both fields through `ProviderEntity.to_simple_provider()`.
- Cover the conversion with distinct dark icon values.

## Tests

- `just check`
- `uv run pytest tests/interfaces/model/test_construct_model_provider.py -q`
- `just test` (`97 passed`, `1 skipped`)
