### PR TITLE
feat(tool): support multi-select parameter declarations

### DIFF
--- a/src/dify_plugin/entities/tool.py
+++ b/src/dify_plugin/entities/tool.py
@@ -5,6 +5,7 @@ from typing import Any
 from pydantic import (
     BaseModel,
     Field,
+    JsonValue,
     field_validator,
     model_validator,
 )
@@ -115,13 +116,38 @@ class ToolParameter(BaseModel):
     )
     llm_description: str | None = None
     required: bool | None = False
-    default: int | float | str | None = None
+    multiple: bool = Field(
+        default=False,
+        description=(
+            "Whether the parameter accepts multiple selections. Only valid for "
+            "select and dynamic-select types"
+        ),
+    )
+    default: JsonValue = None
     min: float | int | None = None
     max: float | int | None = None
     precision: int | None = None
     options: list[ToolParameterOption] | None = None
     # MCP object and array type parameters use this field to store the schema
     input_schema: Mapping[str, Any] | None = None
+
+    @model_validator(mode="after")
+    def validate_multiple(self) -> "ToolParameter":
+        supports_multiple = self.type in {
+            ToolParameter.ToolParameterType.SELECT,
+            ToolParameter.ToolParameterType.DYNAMIC_SELECT,
+        }
+        if self.multiple and not supports_multiple:
+            msg = "multiple is only valid for select and dynamic-select parameters"
+            raise ValueError(msg)
+        if (
+            supports_multiple
+            and self.default is not None
+            and (isinstance(self.default, list) != self.multiple)
+        ):
+            msg = "default must be a list exactly when multiple is true"
+            raise ValueError(msg)
+        return self
 
 
 @docs(

--- a/tests/entities/test_tool.py
+++ b/tests/entities/test_tool.py
@@ -1,0 +1,46 @@
+import pytest
+
+from dify_plugin.entities.tool import ToolParameter
+
+
+def test_tool_parameter_supports_multiple_select() -> None:
+    data = {
+        "name": "formats",
+        "label": {"en_US": "Formats"},
+        "human_description": {"en_US": "Formats to include"},
+        "type": "select",
+        "form": "form",
+        "multiple": True,
+        "default": ["markdown", "links"],
+    }
+    parameter = ToolParameter.model_validate(data)
+
+    assert parameter.model_dump(include={"multiple", "default"}) == {
+        "multiple": True,
+        "default": ["markdown", "links"],
+    }
+    boolean_parameter = ToolParameter.model_validate(
+        data | {"type": "boolean", "multiple": False, "default": True}
+    )
+    assert boolean_parameter.default is True
+
+
+@pytest.mark.parametrize(
+    "values",
+    [
+        {"type": "string", "multiple": True, "default": ["markdown"]},
+        {"type": "select", "multiple": True, "default": "markdown"},
+        {"type": "select", "multiple": False, "default": ["markdown"]},
+    ],
+)
+def test_tool_parameter_rejects_invalid_multiple_select(
+    values: dict[str, object],
+) -> None:
+    with pytest.raises(ValueError, match="multiple"):
+        ToolParameter.model_validate({
+            "name": "formats",
+            "label": {"en_US": "Formats"},
+            "human_description": {"en_US": "Formats to include"},
+            "form": "form",
+            **values,
+        })


### PR DESCRIPTION
## Summary

Allow tool manifests to declare multi-select `select` and `dynamic-select` parameters.

Model parameter defaults as JSON values so array defaults round-trip without coercing booleans or excluding object and array defaults.

Validate that `multiple` is only used with select-style parameters and that select defaults match their declared cardinality.

This PR provides only the SDK-side manifest parsing and serialization requested by https://github.com/langgenius/dify/issues/29180.

Daemon support already shipped in https://github.com/langgenius/dify-plugin-daemon/pull/523.

Dify application and UI integration remain outside this repository.

## Compatibility

Existing valid tool manifests are unchanged.

`multiple` defaults to `false`.

Multi-select declarations require plugin-daemon 0.5.0 or newer and matching Dify application support.

## Testing

- `just check`
- `just test` (`104 passed`, `1 skipped`)