### PR TITLE
fix: get event handler safely

### DIFF
--- a/src/dify_plugin/core/trigger_factory.py
+++ b/src/dify_plugin/core/trigger_factory.py
@@ -157,7 +157,9 @@ class TriggerFactory:
     def get_trigger_event_handler_safely(
         self, provider_name: str, event: str, runtime: EventRuntime
     ) -> Event | None:
-        entry = self._get_entry(provider_name)
+        entry = self._providers.get(provider_name)
+        if entry is None:
+            return None
         if event not in entry.events:
             return None
         _, event_cls = entry.events[event]

--- a/tests/test_trigger_factory.py
+++ b/tests/test_trigger_factory.py
@@ -334,6 +334,13 @@ def test_trigger_factory_error_handling() -> None:
     factory = TriggerFactory()
     session = MagicMock(spec=Session)
 
+    assert (
+        factory.get_trigger_event_handler_safely(
+            "non_existent", "non_existent", MagicMock(spec=EventRuntime)
+        )
+        is None
+    )
+
     # Test getting non-existent provider
     with pytest.raises(ValueError, match="Trigger provider `non_existent` not found"):
         factory.get_trigger_provider("non_existent", session, None, None)


### PR DESCRIPTION
# Pull Request Checklist

An error occurred in `dynamic-options` API when trying to get dynamic parameters for `search repository` tool of `github` plugin. `get_trigger_event_handler_safely` seems not safely handling `ValueError`

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/server/io_server.py", line 94, in _execute_request_in_thread
    self._execute_request(
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/plugin.py", line 455, in _execute_request
    response = self.dispatch(session, data)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/server/router.py", line 79, in dispatch
    return route.func(session, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/server/router.py", line 72, in wrapper
    return f(session, data)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/plugin_executor.py", line 607, in fetch_parameter_options
    action_instance: DynamicSelectProtocol | None = self._get_dynamic_parameter_action(session=session, data=data)
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/plugin_executor.py", line 453, in _get_dynamic_parameter_action
    trigger_event: Event | None = self.registration.try_get_trigger_event_handler(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/plugin_registration.py", line 520, in try_get_trigger_event_handler
    return self.trigger_factory.get_trigger_event_handler_safely(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/trigger_factory.py", line 143, in get_trigger_event_handler_safely
    entry = self._get_entry(provider_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/trigger_factory.py", line 181, in _get_entry
    raise ValueError(f"Trigger provider `{provider_name}` not found") from exc
ValueError: Trigger provider `github` not found
127.0.0.1 - - [2025-12-08 07:42:06] "POST /invoke?action=fetch_parameter_options HTTP/1.0" 200 410 0.001878
Unexpected error occurred when executing request
Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/trigger_factory.py", line 179, in _get_entry
    return self._providers[provider_name]
           ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
KeyError: 'github'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/server/io_server.py", line 94, in _execute_request_in_thread
    self._execute_request(
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/plugin.py", line 455, in _execute_request
    response = self.dispatch(session, data)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/server/router.py", line 79, in dispatch
    return route.func(session, data)
           ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/server/router.py", line 72, in wrapper
    return f(session, data)
           ^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/plugin_executor.py", line 607, in fetch_parameter_options
    action_instance: DynamicSelectProtocol | None = self._get_dynamic_parameter_action(session=session, data=data)
                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/plugin_executor.py", line 453, in _get_dynamic_parameter_action
    trigger_event: Event | None = self.registration.try_get_trigger_event_handler(
                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/plugin_registration.py", line 520, in try_get_trigger_event_handler
    return self.trigger_factory.get_trigger_event_handler_safely(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/trigger_factory.py", line 143, in get_trigger_event_handler_safely
    entry = self._get_entry(provider_name)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.12/site-packages/dify_plugin/core/trigger_factory.py", line 181, in _get_entry
    raise ValueError(f"Trigger provider `{provider_name}` not found") from exc
ValueError: Trigger provider `github` not found
```

## Compatibility Check

- [ ] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [ ] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [ ] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [ ] I have described the compatibility impact and the corresponding version number in the PR description
- [ ] I have checked whether the plugin version is updated in the `README.md`

## Available Checks

- [ ] Code has passed local tests
- [ ] Relevant documentation has been updated (if necessary)
