### PR TITLE
fix(integration): support all plugin invoke actions

### DIFF
--- a/src/dify_plugin/core/entities/plugin/request.py
+++ b/src/dify_plugin/core/entities/plugin/request.py
@@ -103,6 +103,7 @@ PluginAccessAction = (
     | ToolActions
     | ModelActions
     | EndpointActions
+    | OAuthActions
     | DynamicParameterActions
     | DatasourceActions
 )

--- a/src/dify_plugin/integration/entities.py
+++ b/src/dify_plugin/integration/entities.py
@@ -5,18 +5,15 @@ from typing import Any
 from pydantic import BaseModel
 
 from dify_plugin.core.entities.plugin.request import (
-    AgentActions,
-    EndpointActions,
-    ModelActions,
+    PluginAccessAction,
     PluginInvokeType,
-    ToolActions,
 )
 
 
 class PluginInvokeRequest[T: BaseModel](BaseModel):
     invoke_id: str
     type: PluginInvokeType
-    action: AgentActions | ToolActions | ModelActions | EndpointActions
+    action: PluginAccessAction
     request: T
 
 

--- a/tests/integration/test_entities.py
+++ b/tests/integration/test_entities.py
@@ -1,0 +1,47 @@
+import json
+
+from pydantic import BaseModel
+
+from dify_plugin.core.entities.plugin.request import (
+    AgentActions,
+    DatasourceActions,
+    DynamicParameterActions,
+    EndpointActions,
+    ModelActions,
+    OAuthActions,
+    PluginInvokeType,
+    ToolActions,
+    TriggerActions,
+)
+from dify_plugin.integration.entities import PluginInvokeRequest
+
+
+class EmptyRequest(BaseModel):
+    pass
+
+
+def test_plugin_invoke_request_supports_every_action() -> None:
+    actions_by_type = {
+        PluginInvokeType.Agent: AgentActions,
+        PluginInvokeType.Tool: ToolActions,
+        PluginInvokeType.Model: ModelActions,
+        PluginInvokeType.Endpoint: EndpointActions,
+        PluginInvokeType.Trigger: TriggerActions,
+        PluginInvokeType.OAuth: OAuthActions,
+        PluginInvokeType.Datasource: DatasourceActions,
+        PluginInvokeType.DynamicParameter: DynamicParameterActions,
+    }
+
+    assert set(actions_by_type) == set(PluginInvokeType)
+    for invoke_type, actions in actions_by_type.items():
+        for action in actions:
+            request = json.loads(
+                PluginInvokeRequest(
+                    invoke_id="test",
+                    type=invoke_type,
+                    action=action,
+                    request=EmptyRequest(),
+                ).model_dump_json()
+            )
+            assert request["type"] == invoke_type.value
+            assert request["action"] == action.value


### PR DESCRIPTION
## Summary

- Reuse the canonical `PluginAccessAction` type in the integration runner envelope.
- Add the missing `OAuthActions` family to that canonical action type.
- Add a regression test covering all 8 invoke types and all 37 actions.

## Problem

`PluginRunner.invoke()` constructs a `PluginInvokeRequest` before writing anything to the CLI process.

That envelope maintained a second action union containing only Agent, Tool, Model, and Endpoint actions.

As the plugin protocol gained Trigger, Datasource, DynamicParameter, and OAuth actions, the duplicated union was never updated.

Pydantic therefore rejected those requests before JSON serialization, so the daemon and plugin handlers never received them.

The original patch added only Trigger and Datasource actions, leaving DynamicParameter and OAuth requests affected by the same bug.

## Root cause

The accepted action set had two independently maintained definitions.

`PluginRunner.invoke()` already accepts `PluginAccessAction`, while `PluginInvokeRequest` repeated an incomplete subset of that type.

## Solution

`PluginInvokeRequest.action` now directly uses `PluginAccessAction`.

`PluginAccessAction` now includes `OAuthActions`, making it complete for every current `PluginInvokeType`.

The regression test iterates every action family and verifies that each envelope can be constructed and serialized to JSON.

## Compatibility

- No wire field, action value, or existing request behavior changes.
- The change only permits action values that are already part of the plugin protocol.
- No plugin manifest or README version update is required.

## Verification

- [x] `just check`
- [x] `just test` — 100 passed, 1 skipped because the external Dify CLI is unavailable locally.
- [x] `just build`
- [x] Targeted `ty check` for the changed integration paths and regression test.
- [x] Documentation is not required for this internal consistency fix.

## Context

- Original failure report: https://github.com/langgenius/dify-official-plugins/actions/runs/20295949196/job/58289586117?pr=2274
- Trigger integration test that exposed the issue: https://github.com/langgenius/dify-official-plugins/pull/2274
