### PR TITLE
docs(trigger): clarify idempotent subscription deletion

### DIFF
--- a/src/dify_plugin/interfaces/trigger/trigger.py
+++ b/src/dify_plugin/interfaces/trigger/trigger.py
@@ -505,6 +505,8 @@ class TriggerSubscriptionConstructor(ABC, OAuthProviderProtocol):
         4. Always return UnsubscribeResult with detailed status
         5. Never raise exceptions for operational failures. Use
            UnsubscribeResult.success=False.
+        6. Return `UnsubscribeResult(success=True, ...)` when the external service
+           unambiguously reports that the subscription is already absent.
 
         Args:
             subscription: The Subscription object with endpoint and properties fields


### PR DESCRIPTION
Closes #368

## Summary

Clarify that trigger subscription deletion is idempotent when the external subscription is already absent.

Implementations should return `UnsubscribeResult(success=True)` because the requested end state has already been reached.

## Changes

- Document the already-absent subscription case in the `_delete_subscription` implementation guidelines.
- Keep the change limited to the current trigger interface documentation.
- Do not restore the removed GitHub trigger example.

## Compatibility

This is a documentation-only change.

It does not change runtime behavior, public types, dependencies, schemas, or manifests.

## Safety

Providers should only treat the operation as successful when the external service unambiguously reports that the subscription is absent.

This guidance does not define every HTTP `404` response as success.

## Test plan

- [x] `just check`
- [x] `just test`
