### PR TITLE
Make validate credentials max tokens configurable

### DIFF
--- a/python/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -183,7 +183,11 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                 endpoint_url += "/"
 
             # prepare the payload for a simple ping to the model
-            data = {"model": credentials.get("endpoint_model_name", model), "max_tokens": 5}
+            validate_credentials_max_tokens = credentials.get("validate_credentials_max_tokens", 5) or 5
+            data = {
+                "model": credentials.get("endpoint_model_name", model),
+                "max_tokens": validate_credentials_max_tokens,
+            }
 
             completion_type = LLMMode.value_of(credentials["mode"])
 
@@ -201,8 +205,11 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
             # ADD stream validate_credentials
             stream_mode_auth = credentials.get("stream_mode_auth", "not_use")
             if stream_mode_auth == "use":
+                stream_validate_max_tokens = credentials.get("validate_credentials_max_tokens", None) or 10
                 data["stream"] = True
-                data["max_tokens"] = 10
+                # default 10 (introduced in PR #93) to ensure streaming endpoints emit a token chunk;
+                # allow overriding via credentials when explicitly provided.
+                data["max_tokens"] = stream_validate_max_tokens
                 response = requests.post(endpoint_url, headers=headers, json=data, timeout=(10, 300), stream=True)
                 if response.status_code != 200:
                     raise CredentialsValidateFailedError(

--- a/python/pdm.lock
+++ b/python/pdm.lock
@@ -12,7 +12,7 @@ requires_python = ">=3.11"
 
 [[package]]
 name = "annotated-types"
-version = "0.7.1"
+version = "0.7.0"
 requires_python = ">=3.8"
 summary = "Reusable constraint types to use with typing.Annotated"
 groups = ["default"]

--- a/python/pdm.lock
+++ b/python/pdm.lock
@@ -12,7 +12,7 @@ requires_python = ">=3.11"
 
 [[package]]
 name = "annotated-types"
-version = "0.7.0"
+version = "0.7.1"
 requires_python = ">=3.8"
 summary = "Reusable constraint types to use with typing.Annotated"
 groups = ["default"]

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify_plugin"
-version = "0.7.0"
+version = "0.7.1"
 description = "Dify Plugin SDK"
 authors = [{ name = "langgenius", email = "hello@dify.ai" }]
 dependencies = [


### PR DESCRIPTION
## Summary
- allow overriding validate credential ping max_tokens via `validate_credentials_max_tokens` credential value with default fallback
- keep stream validation default max_tokens at 10 (per PR #93) but allow overriding via credentials when specified
- bump SDK version to 0.7.1

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69491f6bf5648326a7880f45f886800d)