### PR TITLE
Make validate_credentials max_tokens configurable and bump SDK version

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dify_plugin"
-version = "0.7.0"
+version = "0.7.1"
 description = "Dify Plugin SDK"
 authors = [{ name = "langgenius", email = "hello@dify.ai" }]
 dependencies = [


### PR DESCRIPTION
### Motivation
- Allow tuning the ping `max_tokens` used during credentials validation so providers with different behaviors can be supported.
- Preserve the streaming validation behavior that historically used `max_tokens=10` to ensure a token chunk is emitted while still permitting explicit overrides.
- Keep project metadata up to date by bumping the SDK package version.

### Description
- Read `validate_credentials_max_tokens` from `credentials` and use it as the ping `max_tokens` for non-stream validation in `python/dify_plugin/interfaces/model/openai_compatible/llm.py`.
- For stream-mode validation, keep the default at `10` but allow overriding when `validate_credentials_max_tokens` is explicitly provided, and add an inline comment explaining the rationale.
- Bump SDK version to `0.7.1` in `python/pyproject.toml` and update `python/pdm.lock` accordingly, and apply small lint/format adjustments in `llm.py`.

### Testing
- Ran `./scripts/fix.sh` which executed `pdm run ruff format` and `pdm run ruff check --fix` and completed successfully with one auto-fix applied.
- No additional automated test suite was executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69491f6bf5648326a7880f45f886800d)