### PR TITLE
fix: close `<think>` block only when `reasoning_content` is None

### DIFF
--- a/python/dify_plugin/interfaces/model/large_language_model.py
+++ b/python/dify_plugin/interfaces/model/large_language_model.py
@@ -537,7 +537,7 @@ if you are not sure about the structure.
         content = delta.get("content") or ""
         reasoning_content = delta.get("reasoning_content")
         output = content
-        if reasoning_content:
+        if reasoning_content is not None:
             if not is_reasoning:
                 output = "<think>\n" + reasoning_content
                 is_reasoning = True
@@ -546,8 +546,7 @@ if you are not sure about the structure.
         else:
             if is_reasoning:
                 is_reasoning = False
-                if not reasoning_content:
-                    output = "\n</think>"
+                output = "\n</think>"
                 if content:
                     output += content
 

--- a/python/tests/interfaces/model/test_wrap_think.py
+++ b/python/tests/interfaces/model/test_wrap_think.py
@@ -62,12 +62,16 @@ class TestWrapThinking(unittest.TestCase):
         chunks = [
             # Chunk 1: Thinking started
             {"reasoning_content": "Thinking started.", "content": ""},
-            # Chunk 2: Still thinking
-            {"reasoning_content": " Still thinking.", "content": ""},
-            # Chunk 3: Thinking ended, transitioned to Tool Call (reasoning_content=None, content=None/Empty)
+            # Chunk 2: Still thinking #1
+            {"reasoning_content": " Still thinking #1.", "content": ""},
+            # Chunk 3: Still thinking (reasoning_content=Empty)
+            {"reasoning_content": "", "content": ""},
+            # Chunk 4: Still thinking #2
+            {"reasoning_content": " Still thinking #2.", "content": ""},
+            # Chunk 5: Thinking ended, transitioned to Tool Call (reasoning_content=None, content=None/Empty)
             # This is a critical point, old logic would fail here because content is empty
             {"reasoning_content": None, "content": "", "tool_calls": [{"id": "call_1", "function": {}}]},
-            # Chunk 4: Subsequent tool parameter stream
+            # Chunk 6: Subsequent tool parameter stream
             {"reasoning_content": None, "content": "", "tool_calls": [{"function": {"arguments": "{"}}]},
         ]
 
@@ -86,13 +90,8 @@ class TestWrapThinking(unittest.TestCase):
         # Verify results
         print(f"DEBUG Output: {full_output!r}")
 
-        assert "<think>" in full_output
-        assert "Thinking started. Still thinking." in full_output
-        assert "</think>" in full_output, "Should verify <think> tag is closed properly"
-
-        # Verify the position of the closing tag: should be after the thinking content
-        expected_part = "Thinking started. Still thinking.\n</think>"
-        assert expected_part in full_output
+        expected_output = "<think>\nThinking started. Still thinking #1. Still thinking #2.\n</think>"
+        self.assertEqual(full_output, expected_output)
 
     def test_standard_reasoning_flow(self):
         """Test standard reasoning -> text flow"""


### PR DESCRIPTION
Fixes #277 

## Compatibility Check

- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [x] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [ ] I have checked whether the plugin version is updated in the `README.md`

## Compatibility impact

Since this is a bug fix, there is no compatibility impact.

## Available Checks

- [x] Code has passed local tests
- [ ] Relevant documentation has been updated (if necessary)

## Before

<img width="1671" height="863" alt="before" src="https://github.com/user-attachments/assets/e10ee43c-6369-4af5-966a-c264a7b039eb" />

## After

<img width="1671" height="863" alt="after" src="https://github.com/user-attachments/assets/7ef19679-0753-4b93-a145-0aa345bc3e80" />