### PR TITLE
fix: handle exception in dynamic select options when trigger is not registered

### DIFF
--- a/python/dify_plugin/core/trigger_factory.py
+++ b/python/dify_plugin/core/trigger_factory.py
@@ -140,11 +140,15 @@ class TriggerFactory:
     # ------------------------------------------------------------------
 
     def get_trigger_event_handler_safely(self, provider_name: str, event: str, runtime: EventRuntime) -> Event | None:
-        entry = self._get_entry(provider_name)
-        if event not in entry.events:
+        try:
+            entry = self._get_entry(provider_name)
+            if event not in entry.events:
+                return None
+            _, event_cls = entry.events[event]
+            return event_cls(runtime)
+        except Exception as e:
+            print(f"Error getting trigger event handler: {e!s}")
             return None
-        _, event_cls = entry.events[event]
-        return event_cls(runtime)
 
     def get_trigger_event_handler(self, provider_name: str, event: str, runtime: EventRuntime) -> Event:
         """Instantiate an event for the given provider and event name."""


### PR DESCRIPTION
## Summary

- Fix unhandled exception in `get_trigger_event_handler_safely()` that broke dynamic select options
- Added try-except block to gracefully handle cases where trigger provider is not registered

## Problem

When using `dynamic-select` parameter type in tools or models, the plugin executor attempts to get a trigger event handler even when no trigger is registered. The `_get_entry()` method raises a `ValueError` when the provider is not found, and this exception was not caught, breaking the entire dynamic select functionality.

## Solution

Wrapped the method body in a try-except block to catch any exceptions and return `None` gracefully. This allows dynamic select to function correctly even when triggers are not involved.

Closes #280