### PR TITLE
fix: Guard response usage in validate_credentials

### DIFF
--- a/python/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/python/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -171,6 +171,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
         :param credentials: model credentials
         :return:
         """
+        response = None
         try:
             headers = {"Content-Type": "application/json"}
 
@@ -255,9 +256,15 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                 )
         except CredentialsValidateFailedError:
             raise
-        except Exception as ex:
+        except requests.RequestException as ex:
             raise CredentialsValidateFailedError(
-                f"An error occurred during credentials validation: {ex!s}, response body {response.text}"
+                f"Credentials validation request failed: {ex!s}"
+            ) from ex
+        except Exception as ex:
+            response_body = response.text if response is not None else "<no response>"
+            raise CredentialsValidateFailedError(
+                f"An error occurred during credentials validation: {ex!s}, "
+                f"response body {response_body}"
             ) from ex
 
     def get_customizable_model_schema(self, model: str, credentials: dict) -> AIModelEntity:


### PR DESCRIPTION
## Summary
Prevent `UnboundLocalError` by ensuring `response` is defined before referencing `response.text` in error handling.
Fixes #287 

## Changes
- Initialize `response = None` at the start of `validate_credentials`.
- In the broad exception handler, use a safe fallback when `response` is unavailable.
- Keep request failures surfaced as `CredentialsValidateFailedError` without secondary errors.

## Why
`requests.post(...)` can raise before `response` is assigned. The previous error handler referenced `response.text` unconditionally, which caused `UnboundLocalError` and masked the real failure. This change preserves the root exception and avoids cascading errors.

## Testing
### Before Change
real error is masked by UnboundLocalError
<img width="1826" height="938" alt="image" src="https://github.com/user-attachments/assets/0f823c4c-135e-43b6-9775-b6ae8a91dd02" />


### After Change
real error is displayed properly
<img width="1576" height="730" alt="image" src="https://github.com/user-attachments/assets/d06f6fb2-8779-444f-85ae-dd941c95798c" />

