### PR TITLE
chore(ci): migrate runners to depot

### DIFF
--- a/.github/workflows/mkdocs.yml
+++ b/.github/workflows/mkdocs.yml
@@ -17,7 +17,7 @@ jobs:
         python-version:
           - 3.12
 
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -19,7 +19,7 @@ concurrency:
 jobs:
   validate-pr-title:
     name: Validate PR title
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       pull-requests: read
     steps:
@@ -43,7 +43,7 @@ jobs:
 
   check:
     name: Check
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     steps:

--- a/.github/workflows/pypi_publish.yaml
+++ b/.github/workflows/pypi_publish.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   verify-tag:
     name: Verify release tag
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     outputs:
@@ -54,7 +54,7 @@ jobs:
 
   build:
     name: Build release distributions
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     needs: verify-tag
     permissions:
       contents: read
@@ -82,7 +82,7 @@ jobs:
 
   pypi-publish:
     name: Publish package distributions to PyPI
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     needs:
       - verify-tag
       - build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ permissions: {}
 jobs:
   test:
     name: Test (Python ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-24.04
     permissions:
       contents: read
     strategy:


### PR DESCRIPTION
Migrate GitHub-hosted workflow runners to Depot runners.

- Replace ubuntu-latest / ubuntu-22.04 with depot-ubuntu-24.04
- Use depot-ubuntu-24.04-4 for higher compute build jobs