### PR TITLE
fix(openai_compatible): handle None tool.description in function_call format and token counting

### DIFF
--- a/src/dify_plugin/entities/tool.py
+++ b/src/dify_plugin/entities/tool.py
@@ -359,7 +359,7 @@ class ToolSelector(BaseModel):
         for name, parameter in self.tool_parameters.items():
             tool.parameters[name] = {
                 "type": parameter.type.value,
-                "description": parameter.description,
+                "description": parameter.description or "",
             }
 
             if parameter.required:

--- a/src/dify_plugin/interfaces/agent/strategy.py
+++ b/src/dify_plugin/interfaces/agent/strategy.py
@@ -302,7 +302,7 @@ class AgentStrategy(ToolLike[AgentInvokeMessage]):
         """Convert tool to prompt message tool"""
         message_tool = PromptMessageTool(
             name=tool.identity.name,
-            description=tool.description.llm if tool.description else "",
+            description=(tool.description.llm or "") if tool.description else "",
             parameters={
                 "type": "object",
                 "properties": {},

--- a/src/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/src/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -598,7 +598,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                 data["functions"] = [
                     {
                         "name": tool.name,
-                        "description": tool.description,
+                        "description": tool.description or "",
                         "parameters": tool.parameters,
                     }
                     for tool in tools
@@ -1127,7 +1127,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                 num_tokens += self._get_num_tokens_by_gpt2(tool.name)
             num_tokens += self._get_num_tokens_by_gpt2("description")
             if hasattr(tool, "description"):
-                num_tokens += self._get_num_tokens_by_gpt2(tool.description)
+                num_tokens += self._get_num_tokens_by_gpt2(tool.description or "")
             if hasattr(tool, "parameters"):
                 parameters = tool.parameters
                 num_tokens += self._get_num_tokens_by_gpt2("parameters")


### PR DESCRIPTION
## Bug Description

Two crash points in `OAICompatLargeLanguageModel` when `tool.description` is `None`:

1. **Line 601** — `"description": tool.description` passes `None` into the function_call payload
2. **Line 1130** — `_get_num_tokens_by_gpt2(tool.description)` crashes with `TypeError`

```
TypeError: can only concatenate str (not "NoneType") to str
```

## Root Cause

`PromptMessageTool.description` is typed as `str` but receives `None` in practice when using custom OpenAPI-based tool providers. The tool provider chain (`ApiToolBundle.summary` → `ToolDescription.llm` → `PromptMessageTool.description`) can produce `None` at several points.

## Fix

Add `or ""` fallback to both lines — minimal, safe, consistent with the guard already used in the `azure_openai` plugin (line 472):

```python
# Line 601
"description": tool.description or "",

# Line 1130  
num_tokens += self._get_num_tokens_by_gpt2(tool.description or "")
```

## Impact

This bug blocks **all** agent invocations that use custom API tools with missing descriptions on any plugin that inherits from `OAICompatLargeLanguageModel` (OpenAI, Azure OpenAI, Ollama, etc).

## How to Reproduce

1. Create an OpenAPI tool provider with endpoints that have `summary` but no `description`
2. Create an Agent using those tools  
3. Invoke the agent → crash before any tool call

## Related

- langgenius/dify-official-plugins#3095 — same bug in `azure_openai` plugin's own `_num_tokens_for_tools`