### PR TITLE
feat(tool): support date parameter types

### DIFF
--- a/src/dify_plugin/entities/provider_config.py
+++ b/src/dify_plugin/entities/provider_config.py
@@ -38,6 +38,8 @@ class CommonParameterType(Enum):
     OBJECT = "object"
     ARRAY = "array"
     DYNAMIC_SELECT = "dynamic-select"
+    DATE = "date"
+    DATE_PICKER = "date-picker"
 
 
 @docs(

--- a/src/dify_plugin/entities/tool.py
+++ b/src/dify_plugin/entities/tool.py
@@ -92,6 +92,22 @@ class ToolParameter(BaseModel):
         OBJECT = CommonParameterType.OBJECT.value
         ARRAY = CommonParameterType.ARRAY.value
         DYNAMIC_SELECT = CommonParameterType.DYNAMIC_SELECT.value
+        DATE = CommonParameterType.DATE.value
+        DATE_PICKER = CommonParameterType.DATE_PICKER.value
+
+        def to_prompt_schema(self, description: str) -> dict[str, Any]:
+            if self in {self.SELECT, self.SECRET_INPUT, self.DATE}:
+                return {"type": self.STRING.value, "description": description}
+            if self == self.DATE_PICKER:
+                return {
+                    "type": self.OBJECT.value,
+                    "description": description,
+                    "properties": {
+                        "start": {"type": self.STRING.value},
+                        "end": {"type": self.STRING.value},
+                    },
+                }
+            return {"type": self.value, "description": description}
 
     class ToolParameterForm(Enum):
         SCHEMA = "schema"  # should be set while adding tool
@@ -384,16 +400,16 @@ class ToolSelector(BaseModel):
         )
 
         for name, parameter in self.tool_parameters.items():
-            tool.parameters[name] = {
-                "type": parameter.type.value,
-                "description": parameter.description or "",
-            }
+            parameter_schema = parameter.type.to_prompt_schema(
+                parameter.description or "",
+            )
+            tool.parameters["properties"][name] = parameter_schema
 
             if parameter.required:
                 tool.parameters["required"].append(name)
 
             if parameter.options:
-                tool.parameters[name]["enum"] = [
+                parameter_schema["enum"] = [
                     option.value for option in parameter.options
                 ]
 

--- a/src/dify_plugin/interfaces/agent/strategy.py
+++ b/src/dify_plugin/interfaces/agent/strategy.py
@@ -31,6 +31,7 @@ FILE_PARAMETER_TYPES = frozenset({
 STRING_PARAMETER_TYPES = frozenset({
     ToolParameter.ToolParameterType.SELECT,
     ToolParameter.ToolParameterType.SECRET_INPUT,
+    ToolParameter.ToolParameterType.DATE,
 })
 
 
@@ -299,17 +300,11 @@ class AgentStrategy(ToolLike[AgentInvokeMessage]):
         if parameter.form != ToolParameter.ToolParameterForm.LLM:
             return
 
-        parameter_type = parameter.type
         if parameter.type in FILE_PARAMETER_TYPES:
             return
-        if parameter.type in STRING_PARAMETER_TYPES:
-            parameter_type = ToolParameter.ToolParameterType.STRING
 
         prompt_tool.parameters["properties"][parameter.name] = (
-            {
-                "type": parameter_type,
-                "description": parameter.llm_description or "",
-            }
+            parameter.type.to_prompt_schema(parameter.llm_description or "")
             if parameter.input_schema is None
             else dict(parameter.input_schema)
         )

--- a/tests/entities/test_tool.py
+++ b/tests/entities/test_tool.py
@@ -1,6 +1,6 @@
 import pytest
 
-from dify_plugin.entities.tool import ToolParameter
+from dify_plugin.entities.tool import ToolParameter, ToolSelector
 
 
 def test_tool_parameter_supports_multiple_select() -> None:
@@ -82,3 +82,59 @@ def test_tool_parameter_preserves_show_on_conditions() -> None:
     assert defaulted.show_on == []
     assert defaulted.options
     assert defaulted.options[0].show_on == []
+
+
+def test_tool_selector_converts_date_parameters_to_prompt_schema() -> None:
+    selector = ToolSelector.model_validate({
+        "provider_id": "calendar",
+        "tool_name": "schedule",
+        "tool_description": "Schedule an event",
+        "tool_configuration": {},
+        "tool_parameters": {
+            "day": {
+                "name": "day",
+                "type": "date",
+                "required": True,
+                "description": "Event date",
+            },
+            "range": {
+                "name": "range",
+                "type": "date-picker",
+                "required": False,
+                "description": "Event date range",
+            },
+            "timezone": {
+                "name": "timezone",
+                "type": "select",
+                "required": False,
+                "description": "Timezone",
+                "options": [
+                    {
+                        "value": "UTC",
+                        "label": {"en_US": "UTC"},
+                    }
+                ],
+            },
+        },
+    })
+
+    assert selector.to_prompt_message().parameters == {
+        "type": "object",
+        "properties": {
+            "day": {"type": "string", "description": "Event date"},
+            "range": {
+                "type": "object",
+                "description": "Event date range",
+                "properties": {
+                    "start": {"type": "string"},
+                    "end": {"type": "string"},
+                },
+            },
+            "timezone": {
+                "type": "string",
+                "description": "Timezone",
+                "enum": ["UTC"],
+            },
+        },
+        "required": ["day"],
+    }

--- a/tests/interfaces/agent/test_agent.py
+++ b/tests/interfaces/agent/test_agent.py
@@ -106,6 +106,30 @@ def test_agent_strategy_converts_tool_parameters_once() -> None:
                 type=ToolParameter.ToolParameterType.FILE,
                 form=ToolParameter.ToolParameterForm.LLM,
             ),
+            ToolParameter(
+                name="day",
+                label=label,
+                human_description=label,
+                type=ToolParameter.ToolParameterType.DATE,
+                form=ToolParameter.ToolParameterForm.LLM,
+                llm_description="Event date",
+            ),
+            ToolParameter(
+                name="range",
+                label=label,
+                human_description=label,
+                type=ToolParameter.ToolParameterType.DATE_PICKER,
+                form=ToolParameter.ToolParameterForm.LLM,
+                llm_description="Event date range",
+            ),
+            ToolParameter(
+                name="custom_range",
+                label=label,
+                human_description=label,
+                type=ToolParameter.ToolParameterType.DATE_PICKER,
+                form=ToolParameter.ToolParameterForm.LLM,
+                input_schema={"type": "string"},
+            ),
         ],
     )
 
@@ -120,3 +144,16 @@ def test_agent_strategy_converts_tool_parameters_once() -> None:
     assert tool.parameters[0].input_schema == {"type": "string"}
     assert "upload" not in prompt_tool.parameters["properties"]
     assert prompt_tool.parameters["required"] == ["query"]
+    assert prompt_tool.parameters["properties"]["day"] == {
+        "type": "string",
+        "description": "Event date",
+    }
+    assert prompt_tool.parameters["properties"]["range"] == {
+        "type": "object",
+        "description": "Event date range",
+        "properties": {
+            "start": {"type": "string"},
+            "end": {"type": "string"},
+        },
+    }
+    assert prompt_tool.parameters["properties"]["custom_range"] == {"type": "string"}


### PR DESCRIPTION
Part of langgenius/dify#36162.

## Summary

- Add `date` and `date-picker` tool parameter types.
- Map `date` to a JSON Schema string for model tool calls.
- Map `date-picker` to an object with optional string `start` and `end` properties.
- Reuse the same conversion for tool selectors and agent strategies.
- Keep explicit `input_schema` values authoritative.
- Keep provider credential configuration unchanged.

## Contract

`date-picker` values are normalized to `{start?: string, end?: string}` by the proposed Dify integration in langgenius/dify#36163.

This SDK does not add ISO date validation or range ordering before that contract is defined at the shared input boundary.

Related daemon support is tracked by langgenius/dify-plugin-daemon#733.

## Validation

- `uv run pytest tests/entities/test_tool.py tests/interfaces/agent/test_agent.py -q`
- `just docs`
- `just check`
- `just test`

All checks pass locally: 187 tests passed and 1 integration test was skipped.