### PR TITLE
chore: reduce global Ruff ignore list

### DIFF
--- a/examples/agent/strategies/function_calling.py
+++ b/examples/agent/strategies/function_calling.py
@@ -537,7 +537,7 @@ class FunctionCallingAgentStrategy(AgentStrategy):
             return
 
         if tool_invoke_response.type == ToolInvokeMessage.MessageType.BLOB:
-            # TODO: convert to agent invoke message
+            # Conversion to an agent invoke message remains open here.
             yield tool_invoke_response
             text_parts.append("Generated file ... ")
             return
@@ -556,7 +556,7 @@ class FunctionCallingAgentStrategy(AgentStrategy):
             ).text
             yield from self._create_image_blob_message(file_info)
 
-        # TODO: convert to agent invoke message
+        # Conversion to an agent invoke message remains open here.
         yield tool_invoke_response
         text_parts.append(
             "image has been created and sent to user already, "

--- a/examples/agent/strategies/react.py
+++ b/examples/agent/strategies/react.py
@@ -202,7 +202,7 @@ class ReActAgentStrategy(AgentStrategy):
                 if isinstance(chunk, AgentScratchpadUnit.Action):
                     action = chunk
                     # detect action
-                    assert scratchpad.agent_response is not None
+                    scratchpad.agent_response = scratchpad.agent_response or ""
                     scratchpad.agent_response += json.dumps(chunk.model_dump())
 
                     scratchpad.action_str = json.dumps(chunk.model_dump())
@@ -297,7 +297,7 @@ class ReActAgentStrategy(AgentStrategy):
                     scratchpad.observation = tool_invoke_response
                     scratchpad.agent_response = tool_invoke_response
 
-                    # TODO: convert to agent invoke message
+                    # Conversion to an agent invoke message remains open here.
                     yield from additional_messages
                     yield self.finish_log_message(
                         log=tool_call_log,
@@ -393,20 +393,18 @@ class ReActAgentStrategy(AgentStrategy):
             assistant_messages = []
         else:
             assistant_message = AssistantPromptMessage(content="")
+            assistant_content = cast("str", assistant_message.content)
             for unit in agent_scratchpad:
                 if unit.is_final():
-                    assert isinstance(assistant_message.content, str)
-                    assistant_message.content += f"Final Answer: {unit.agent_response}"
+                    assistant_content += f"Final Answer: {unit.agent_response}"
                 else:
-                    assert isinstance(assistant_message.content, str)
-                    assistant_message.content += f"Thought: {unit.thought}\n\n"
+                    assistant_content += f"Thought: {unit.thought}\n\n"
                     if unit.action_str:
-                        assistant_message.content += f"Action: {unit.action_str}\n\n"
+                        assistant_content += f"Action: {unit.action_str}\n\n"
                     if unit.observation:
-                        assistant_message.content += (
-                            f"Observation: {unit.observation}\n\n"
-                        )
+                        assistant_content += f"Observation: {unit.observation}\n\n"
 
+            assistant_message.content = assistant_content
             assistant_messages = [assistant_message]
 
         # query messages

--- a/examples/github/provider/github.py
+++ b/examples/github/provider/github.py
@@ -79,7 +79,7 @@ class GithubProvider(ToolProvider):
         """
         del redirect_uri
         del system_credentials
-        # TODO: Implement the refresh credentials logic
+        # Credential refresh is currently a no-op; credentials are returned unchanged.
         return ToolOAuthCredentials(credentials=credentials, expires_at=-1)
 
     def _validate_credentials(self, credentials: dict) -> None:

--- a/examples/github_trigger/provider/github.py
+++ b/examples/github_trigger/provider/github.py
@@ -79,6 +79,27 @@ ADDITIONAL_UNIFIED_EVENTS = frozenset({
     "deploy_key",
     "watch",
 })
+EVENT_ALIASES = {
+    **dict.fromkeys(SECRET_SCANNING_EVENTS, "secret_scanning"),
+    **dict.fromkeys(REF_CHANGE_EVENTS, "ref_change"),
+}
+UNIFIED_EVENTS = (
+    CORE_EVENTS
+    | REVIEW_AND_CI_EVENTS
+    | BRANCH_PROTECTION_EVENTS
+    | ADDITIONAL_UNIFIED_EVENTS
+    | frozenset({
+        "push",
+        "star",
+        "code_scanning_alert",
+        "commit_comment",
+        "status",
+        "deployment",
+        "dependabot_alert",
+        "repository_vulnerability_alert",
+        "repository_ruleset",
+    })
+)
 
 
 class GithubTrigger(Trigger):
@@ -111,12 +132,7 @@ class GithubTrigger(Trigger):
     ) -> list[str]:
         event_type = event_type.lower()
         action: str | None = payload.get("action")
-        # Unified core events (breaking change): issues / issue_comment / pull_request
-        if event_type in CORE_EVENTS:
-            return [event_type]
-
-        # Unified review & CI events (breaking change)
-        if event_type in REVIEW_AND_CI_EVENTS:
+        if event_type in UNIFIED_EVENTS:
             return [event_type]
 
         if event_type in ACTION_SUFFIX_EVENTS:
@@ -125,46 +141,9 @@ class GithubTrigger(Trigger):
                 raise TriggerDispatchError(msg)
             return [f"{event_type}_{action}"]
 
-        if event_type == "push":
-            return ["push"]
-
-        if event_type == "star":
-            return ["star"]
-
-        # Unified events without action splitting
-        if event_type == "code_scanning_alert":
-            return ["code_scanning_alert"]
-
-        if event_type in SECRET_SCANNING_EVENTS:
-            return ["secret_scanning"]
-
-        if event_type in REF_CHANGE_EVENTS:
-            return ["ref_change"]
-
-        if event_type == "commit_comment":
-            return ["commit_comment"]
-
-        if event_type == "status":
-            return ["status"]
-
-        if event_type == "deployment":
-            return ["deployment"]
-
-        if event_type == "dependabot_alert":
-            return ["dependabot_alert"]
-
-        if event_type == "repository_vulnerability_alert":
-            return ["repository_vulnerability_alert"]
-
-        if event_type in BRANCH_PROTECTION_EVENTS:
-            return [event_type]
-
-        if event_type == "repository_ruleset":
-            return ["repository_ruleset"]
-
-        # Additional unified GitHub events (breaking change by design)
-        if event_type in ADDITIONAL_UNIFIED_EVENTS:
-            return [event_type]
+        alias = EVENT_ALIASES.get(event_type)
+        if alias:
+            return [alias]
 
         return []
 

--- a/examples/gmail_trigger/events/gmail_message_added/gmail_message_added.py
+++ b/examples/gmail_trigger/events/gmail_message_added/gmail_message_added.py
@@ -348,11 +348,7 @@ class GmailMessageAddedEvent(Event):
         headers: Mapping[str, str],
     ) -> tuple[bytes | None, int | None]:
         if inline_data:
-            try:
-                content = self._decode_base64url(inline_data)
-            except binascii.Error:
-                return None, None
-            return content, len(content)
+            return self._decode_attachment_data(inline_data)
 
         attachment_id = attachment.get("attachmentId")
         if not attachment_id:
@@ -370,7 +366,11 @@ class GmailMessageAddedEvent(Event):
             return None, None
 
         data = response.json() or {}
-        encoded = data.get("data")
+        return self._decode_attachment_data(data.get("data"), data.get("size"))
+
+    def _decode_attachment_data(
+        self, encoded: str | None, size: int | None = None
+    ) -> tuple[bytes | None, int | None]:
         if not encoded:
             return None, None
 
@@ -379,7 +379,6 @@ class GmailMessageAddedEvent(Event):
         except binascii.Error:
             return None, None
 
-        size = data.get("size")
         size_value = size if size is not None else len(content)
         return content, size_value
 

--- a/examples/notion_datasource/datasources/utils/notion_extractor.py
+++ b/examples/notion_datasource/datasources/utils/notion_extractor.py
@@ -49,8 +49,6 @@ class NotionExtractor:
 
     def _get_notion_database_data(self, database_id: str) -> str:
         """Fetch all pages from a Notion database and return as a Markdown table."""
-        assert self._notion_access_token is not None, "Notion access token is required"
-
         # Retrieve database metadata
         database_data = self._client.retrieve_database(database_id=database_id)
 
@@ -100,7 +98,6 @@ class NotionExtractor:
 
     def _get_notion_block_data(self, page_id: str) -> str:
         """Fetch and process Notion block data."""
-        assert self._notion_access_token is not None, "Notion access token is required"
         result_lines_arr = []
 
         # Retrieve page metadata
@@ -208,41 +205,42 @@ class NotionExtractor:
         """Extract the value of a Notion property."""
         column_type = property_value["type"]
         if column_type == "multi_select":
-            return ", ".join(option["name"] for option in property_value[column_type])
-        if column_type in TEXT_PROPERTY_TYPES:
-            return (
+            value = ", ".join(option["name"] for option in property_value[column_type])
+        elif column_type in TEXT_PROPERTY_TYPES:
+            value = (
                 property_value[column_type][0]["plain_text"]
                 if property_value[column_type]
                 else ""
             )
-        if column_type in NAMED_PROPERTY_TYPES:
-            return (
+        elif column_type in NAMED_PROPERTY_TYPES:
+            value = (
                 property_value[column_type]["name"]
                 if property_value[column_type]
                 else ""
             )
-        if column_type == "number":
-            return property_value.get("number")
-        if column_type == "date":
+        elif column_type == "number":
+            value = property_value.get("number")
+        elif column_type == "date":
             date_data = property_value.get("date", {})
-            return (
+            value = (
                 {"start": date_data.get("start"), "end": date_data.get("end")}
                 if date_data
                 else None
             )
-        if column_type == "formula":
+        elif column_type == "formula":
             formula_value = property_value[column_type]
-            return (
+            value = (
                 formula_value.get("number")
                 if isinstance(formula_value, dict)
                 and formula_value.get("type") == "number"
                 else formula_value
             )
-        if column_type == "created_by":
-            # Handle created_by type
+        elif column_type == "created_by":
             created_by_data = property_value.get("created_by", {})
-            return created_by_data.get("name") if created_by_data else None
-        return property_value[column_type]
+            value = created_by_data.get("name") if created_by_data else None
+        else:
+            value = property_value[column_type]
+        return value
 
     def _extract_cell_text(self, cell: list[dict]) -> str:
         """Extract text content from a table cell."""

--- a/examples/notion_datasource/datasources/utils/notion_extractor.py
+++ b/examples/notion_datasource/datasources/utils/notion_extractor.py
@@ -9,8 +9,6 @@ HEADING_SPLITTER = {
     "heading_2": "## ",
     "heading_3": "### ",
 }
-TEXT_PROPERTY_TYPES = frozenset({"rich_text", "title"})
-NAMED_PROPERTY_TYPES = frozenset({"select", "status"})
 
 
 class NotionExtractor:
@@ -209,13 +207,13 @@ class NotionExtractor:
                 value = ", ".join(
                     option["name"] for option in property_value[column_type]
                 )
-            case _ if column_type in TEXT_PROPERTY_TYPES:
+            case "rich_text" | "title":
                 value = (
                     property_value[column_type][0]["plain_text"]
                     if property_value[column_type]
                     else ""
                 )
-            case _ if column_type in NAMED_PROPERTY_TYPES:
+            case "select" | "status":
                 value = (
                     property_value[column_type]["name"]
                     if property_value[column_type]

--- a/examples/notion_datasource/datasources/utils/notion_extractor.py
+++ b/examples/notion_datasource/datasources/utils/notion_extractor.py
@@ -204,42 +204,45 @@ class NotionExtractor:
     def _extract_property_value(self, property_value: dict[str, Any]) -> object:
         """Extract the value of a Notion property."""
         column_type = property_value["type"]
-        if column_type == "multi_select":
-            value = ", ".join(option["name"] for option in property_value[column_type])
-        elif column_type in TEXT_PROPERTY_TYPES:
-            value = (
-                property_value[column_type][0]["plain_text"]
-                if property_value[column_type]
-                else ""
-            )
-        elif column_type in NAMED_PROPERTY_TYPES:
-            value = (
-                property_value[column_type]["name"]
-                if property_value[column_type]
-                else ""
-            )
-        elif column_type == "number":
-            value = property_value.get("number")
-        elif column_type == "date":
-            date_data = property_value.get("date", {})
-            value = (
-                {"start": date_data.get("start"), "end": date_data.get("end")}
-                if date_data
-                else None
-            )
-        elif column_type == "formula":
-            formula_value = property_value[column_type]
-            value = (
-                formula_value.get("number")
-                if isinstance(formula_value, dict)
-                and formula_value.get("type") == "number"
-                else formula_value
-            )
-        elif column_type == "created_by":
-            created_by_data = property_value.get("created_by", {})
-            value = created_by_data.get("name") if created_by_data else None
-        else:
-            value = property_value[column_type]
+        match column_type:
+            case "multi_select":
+                value = ", ".join(
+                    option["name"] for option in property_value[column_type]
+                )
+            case _ if column_type in TEXT_PROPERTY_TYPES:
+                value = (
+                    property_value[column_type][0]["plain_text"]
+                    if property_value[column_type]
+                    else ""
+                )
+            case _ if column_type in NAMED_PROPERTY_TYPES:
+                value = (
+                    property_value[column_type]["name"]
+                    if property_value[column_type]
+                    else ""
+                )
+            case "number":
+                value = property_value.get("number")
+            case "date":
+                date_data = property_value.get("date", {})
+                value = (
+                    {"start": date_data.get("start"), "end": date_data.get("end")}
+                    if date_data
+                    else None
+                )
+            case "formula":
+                formula_value = property_value[column_type]
+                value = (
+                    formula_value.get("number")
+                    if isinstance(formula_value, dict)
+                    and formula_value.get("type") == "number"
+                    else formula_value
+                )
+            case "created_by":
+                created_by_data = property_value.get("created_by", {})
+                value = created_by_data.get("name") if created_by_data else None
+            case _:
+                value = property_value[column_type]
         return value
 
     def _extract_cell_text(self, cell: list[dict]) -> str:

--- a/examples/openai/models/llm/llm.py
+++ b/examples/openai/models/llm/llm.py
@@ -220,12 +220,12 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             prompt_messages[0],
             SystemPromptMessage,
         ):
-            assert isinstance(prompt_messages[0].content, str)
+            system_content = cast("str", prompt_messages[0].content)
             # override the system message
             prompt_messages[0] = SystemPromptMessage(
                 content=OPENAI_BLOCK_MODE_PROMPT.replace(
                     "{{instructions}}",
-                    prompt_messages[0].content,
+                    system_content,
                 ).replace("{{block}}", response_format),
             )
             prompt_messages.append(
@@ -258,7 +258,11 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         user: str | None = None,
         response_format: str = "JSON",
     ) -> None:
-        """Transform json prompts"""
+        """Transform json prompts.
+
+        Raises:
+            ValueError: If no user prompt message is available.
+        """
         del model
         del credentials
         del model_parameters
@@ -280,36 +284,33 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
                 user_message = prompt_messages[i]
                 break
 
-        assert isinstance(i, int)
+        if user_message is None or i is None:
+            msg = "User prompt message is required"
+            raise ValueError(msg)
 
-        if user_message:
-            assert isinstance(prompt_messages, list)
-            assert isinstance(prompt_messages[i], PromptMessage)
-            content = prompt_messages[i].content
-            assert isinstance(content, str)
+        content = cast("str", prompt_messages[i].content)
+        user_content = cast("str", user_message.content)
 
-            if content[-11:] == "Assistant: ":
-                assert isinstance(user_message.content, str)
-                # now we are in the chat app, remove the last assistant message
-                prompt_messages[i].content = content[:-11]
-                prompt_messages[i] = UserPromptMessage(
-                    content=OPENAI_BLOCK_MODE_PROMPT.replace(
-                        "{{instructions}}",
-                        user_message.content,
-                    ).replace("{{block}}", response_format),
-                )
-                prompt_messages[i].content += f"Assistant:\n```{response_format}\n"
-            else:
-                assert isinstance(user_message.content, str)
+        if content[-11:] == "Assistant: ":
+            # now we are in the chat app, remove the last assistant message
+            user_content = content[:-11]
+            prompt_messages[i].content = user_content
+            prompt_messages[i] = UserPromptMessage(
+                content=OPENAI_BLOCK_MODE_PROMPT.replace(
+                    "{{instructions}}",
+                    user_content,
+                ).replace("{{block}}", response_format),
+            )
+            prompt_messages[i].content += f"Assistant:\n```{response_format}\n"
+        else:
+            prompt_messages[i] = UserPromptMessage(
+                content=OPENAI_BLOCK_MODE_PROMPT.replace(
+                    "{{instructions}}",
+                    user_content,
+                ).replace("{{block}}", response_format),
+            )
 
-                prompt_messages[i] = UserPromptMessage(
-                    content=OPENAI_BLOCK_MODE_PROMPT.replace(
-                        "{{instructions}}",
-                        user_message.content,
-                    ).replace("{{block}}", response_format),
-                )
-
-                prompt_messages[i].content += f"\n```{response_format}\n"
+            prompt_messages[i].content += f"\n```{response_format}\n"
 
     def get_num_tokens(
         self,
@@ -340,8 +341,7 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             # chat model
             return self._num_tokens_from_messages(base_model, prompt_messages, tools)
         # text completion model, do not support tool calling
-        content = prompt_messages[0].content
-        assert isinstance(content, str)
+        content = cast("str", prompt_messages[0].content)
         return self._num_tokens_from_string(base_model, content)
 
     def validate_credentials(self, model: str, credentials: dict) -> None:
@@ -499,10 +499,10 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             extra_model_kwargs["stream_options"] = {"include_usage": True}
 
         # text completion model
-        assert isinstance(prompt_messages[0].content, str)
+        prompt_content = cast("str", prompt_messages[0].content)
 
         response = client.completions.create(
-            prompt=prompt_messages[0].content,
+            prompt=prompt_content,
             model=model,
             stream=stream,
             **model_parameters,
@@ -510,19 +510,17 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         )
 
         if stream:
-            assert isinstance(response, Stream)
             return self._handle_generate_stream_response(
                 model,
                 credentials,
-                response,
+                cast("Stream[Completion]", response),
                 prompt_messages,
             )
 
-        assert isinstance(response, Completion)
         return self._handle_generate_response(
             model,
             credentials,
-            response,
+            cast("Completion", response),
             prompt_messages,
         )
 
@@ -556,10 +554,10 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             completion_tokens = response.usage.completion_tokens
         else:
             # calculate num tokens
-            assert isinstance(prompt_messages[0].content, str)
+            prompt_content = cast("str", prompt_messages[0].content)
             prompt_tokens = self._num_tokens_from_string(
                 model,
-                prompt_messages[0].content,
+                prompt_content,
             )
             completion_tokens = self._num_tokens_from_string(model, assistant_text)
 
@@ -648,10 +646,10 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
                 )
 
         if not prompt_tokens:
-            assert isinstance(prompt_messages[0].content, str)
+            prompt_content = cast("str", prompt_messages[0].content)
             prompt_tokens = self._num_tokens_from_string(
                 model,
-                prompt_messages[0].content,
+                prompt_content,
             )
 
         if not completion_tokens:
@@ -892,14 +890,13 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
                 # handle process of stream function call
                 if assistant_message_function_call:
                     # message has not ended ever
-                    assert isinstance(
+                    stored_arguments = cast(
+                        "str",
                         delta_assistant_message_function_call_storage.arguments,
-                        str,
                     )
-                    assert isinstance(assistant_message_function_call.arguments, str)
-
-                    delta_assistant_message_function_call_storage.arguments += (
-                        assistant_message_function_call.arguments
+                    arguments = cast("str", assistant_message_function_call.arguments)
+                    delta_assistant_message_function_call_storage.arguments = (
+                        stored_arguments + arguments
                     )
                     continue
                 else:
@@ -999,9 +996,9 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         tool_calls = []
         if response_tool_calls:
             for response_tool_call in response_tool_calls:
-                assert isinstance(
+                response_tool_call = cast(
+                    "ChatCompletionMessageToolCall | ChoiceDeltaToolCall",
                     response_tool_call,
-                    (ChatCompletionMessageToolCall, ChoiceDeltaToolCall),
                 )
                 if response_tool_call.function:
                     function = AssistantPromptMessage.ToolCall.ToolCallFunction(
@@ -1032,9 +1029,9 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         """
         tool_call = None
         if response_function_call:
-            assert isinstance(
+            response_function_call = cast(
+                "FunctionCall | ChoiceDeltaFunctionCall",
                 response_function_call,
-                (FunctionCall, ChoiceDeltaFunctionCall),
             )
 
             function = AssistantPromptMessage.ToolCall.ToolCallFunction(
@@ -1096,8 +1093,10 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
                 message_dict = {"role": "user", "content": message.content}
             else:
                 sub_messages = []
-                assert isinstance(message.content, list)
-                for message_content in message.content:
+                for message_content in cast(
+                    "list[TextPromptMessageContent | ImagePromptMessageContent]",
+                    message.content,
+                ):
                     if message_content.type == PromptMessageContentType.TEXT:
                         message_content = cast(
                             "TextPromptMessageContent",
@@ -1266,9 +1265,8 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         return len(encoding.encode(str(message_value)))
 
     def _text_from_message_value(self, value: object) -> object:
-        # TODO: The current token calculation method for the image type is not
-        # implemented. It needs to download the image and calculate resolution,
-        # which increases request delay.
+        # Image token calculation remains approximate because exact sizing
+        # requires downloading images and measuring resolution.
         if not isinstance(value, list):
             return value
 

--- a/examples/openai/models/llm/llm.py
+++ b/examples/openai/models/llm/llm.py
@@ -50,6 +50,7 @@ from ..common_openai import _CommonOpenAI
 
 logger = logging.getLogger(__name__)
 EMPTY_STRING = ""
+ASSISTANT_PROMPT_SUFFIX = "Assistant: "
 STRUCTURED_RESPONSE_FORMATS = frozenset({"JSON", "XML"})
 
 OPENAI_BLOCK_MODE_PROMPT = (
@@ -307,9 +308,9 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             "User prompt message content",
         )
 
-        if content[-11:] == "Assistant: ":
+        if content.endswith(ASSISTANT_PROMPT_SUFFIX):
             # now we are in the chat app, remove the last assistant message
-            user_content = content[:-11]
+            user_content = content.removesuffix(ASSISTANT_PROMPT_SUFFIX)
             prompt_messages[i].content = user_content
             prompt_messages[i] = UserPromptMessage(
                 content=OPENAI_BLOCK_MODE_PROMPT.replace(

--- a/examples/openai/models/llm/llm.py
+++ b/examples/openai/models/llm/llm.py
@@ -65,6 +65,13 @@ OPENAI_BLOCK_MODE_PROMPT = (
 )
 
 
+def _require_text_content(content: object, field_name: str) -> str:
+    if not isinstance(content, str):
+        msg = f"{field_name} must be a string"
+        raise TypeError(msg)
+    return content
+
+
 class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
     """Model class for OpenAI large language model."""
 
@@ -220,7 +227,10 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             prompt_messages[0],
             SystemPromptMessage,
         ):
-            system_content = cast("str", prompt_messages[0].content)
+            system_content = _require_text_content(
+                prompt_messages[0].content,
+                "System prompt message content",
+            )
             # override the system message
             prompt_messages[0] = SystemPromptMessage(
                 content=OPENAI_BLOCK_MODE_PROMPT.replace(
@@ -288,8 +298,14 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
             msg = "User prompt message is required"
             raise ValueError(msg)
 
-        content = cast("str", prompt_messages[i].content)
-        user_content = cast("str", user_message.content)
+        content = _require_text_content(
+            prompt_messages[i].content,
+            "Prompt message content",
+        )
+        user_content = _require_text_content(
+            user_message.content,
+            "User prompt message content",
+        )
 
         if content[-11:] == "Assistant: ":
             # now we are in the chat app, remove the last assistant message
@@ -890,11 +906,10 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
                 # handle process of stream function call
                 if assistant_message_function_call:
                     # message has not ended ever
-                    stored_arguments = cast(
-                        "str",
-                        delta_assistant_message_function_call_storage.arguments,
+                    stored_arguments = (
+                        delta_assistant_message_function_call_storage.arguments or ""
                     )
-                    arguments = cast("str", assistant_message_function_call.arguments)
+                    arguments = assistant_message_function_call.arguments or ""
                     delta_assistant_message_function_call_storage.arguments = (
                         stored_arguments + arguments
                     )
@@ -1086,17 +1101,21 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
         return prompt_messages
 
     def _convert_prompt_message_to_dict(self, message: PromptMessage) -> dict:
-        """Convert PromptMessage to dict for OpenAI API"""
+        """Convert PromptMessage to dict for OpenAI API.
+
+        Returns:
+            The prompt message as an OpenAI-compatible dictionary.
+
+        Raises:
+            TypeError: If user prompt content is neither text nor content parts.
+        """
         if isinstance(message, UserPromptMessage):
             message = cast("UserPromptMessage", message)
             if isinstance(message.content, str):
                 message_dict = {"role": "user", "content": message.content}
-            else:
+            elif isinstance(message.content, list):
                 sub_messages = []
-                for message_content in cast(
-                    "list[TextPromptMessageContent | ImagePromptMessageContent]",
-                    message.content,
-                ):
+                for message_content in message.content:
                     if message_content.type == PromptMessageContentType.TEXT:
                         message_content = cast(
                             "TextPromptMessageContent",
@@ -1122,6 +1141,9 @@ class OpenAILargeLanguageModel(_CommonOpenAI, LargeLanguageModel):
                         sub_messages.append(sub_message_dict)
 
                 message_dict = {"role": "user", "content": sub_messages}
+            else:
+                msg = "User prompt message content must be text or content parts"
+                raise TypeError(msg)
         elif isinstance(message, AssistantPromptMessage):
             message = cast("AssistantPromptMessage", message)
             message_dict = {"role": "assistant", "content": message.content}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,17 +59,10 @@ required-version = '>=0.15'
 [tool.ruff.lint]
 select = ['ALL']
 ignore = [
-    'S104',
-    'PLR0911',
-    'T201',
-    'FIX002',
-    'TD002',
-    'TD003',
     'PLR0915', # Too broad for orchestration-heavy SDK/example functions.
     'ERA001',  # False positives are common.
     'PLR0912',
     'PLR0914',
-    'S101',
     'TRY002',
     'BLE001',
     'TRY301',

--- a/src/dify_plugin/config/config.py
+++ b/src/dify_plugin/config/config.py
@@ -44,7 +44,10 @@ class DifyPluginEnv(BaseSettings):
         default=None, description="Remote installation key"
     )
 
-    SERVERLESS_HOST: str = Field(default="0.0.0.0", description="Serverless host")
+    SERVERLESS_HOST: str = Field(
+        default="0.0.0.0",  # noqa: S104
+        description="Serverless host",
+    )
     SERVERLESS_PORT: int = Field(default=8080, description="Serverless port")
     SERVERLESS_WORKER_CLASS: str = Field(
         default="gevent", description="Serverless worker class"

--- a/src/dify_plugin/core/documentation/generator.py
+++ b/src/dify_plugin/core/documentation/generator.py
@@ -2,7 +2,8 @@ import importlib
 import pathlib
 from collections import defaultdict
 from enum import Enum
-from typing import TextIO, Union
+from types import UnionType
+from typing import TextIO, Union, get_args, get_origin
 
 from pydantic import BaseModel
 
@@ -464,23 +465,24 @@ class SchemaDocumentationGenerator:
                 type_name = f"[{name}](#{name.lower()})"
             else:
                 type_name = field_type.__name__
-        elif hasattr(field_type, "__origin__") and hasattr(field_type, "__args__"):
-            origin = field_type.__origin__
-            if origin in COLLECTION_ORIGINS:
-                inner_type = self._format_type_name(field_type.__args__[0])
-                type_name = f"{origin.__name__}[{inner_type}]"
-            elif origin is dict:
-                key_type = self._format_type_name(field_type.__args__[0])
-                value_type = self._format_type_name(field_type.__args__[1])
-                type_name = f"dict[{key_type}, {value_type}]"
-            elif origin is tuple:
-                types = [self._format_type_name(arg) for arg in field_type.__args__]
-                type_name = f"tuple[{', '.join(types)}]"
-            elif origin is Union:
-                types = [self._format_type_name(arg) for arg in field_type.__args__]
-                type_name = f"Union[{', '.join(types)}]"
-            else:
-                type_name = str(field_type)
+        elif (origin := get_origin(field_type)) is not None:
+            type_args = get_args(field_type)
+            match origin:
+                case _ if origin in COLLECTION_ORIGINS:
+                    inner_type = self._format_type_name(type_args[0])
+                    type_name = f"{origin.__name__}[{inner_type}]"
+                case _ if origin is dict:
+                    key_type = self._format_type_name(type_args[0])
+                    value_type = self._format_type_name(type_args[1])
+                    type_name = f"dict[{key_type}, {value_type}]"
+                case _ if origin is tuple:
+                    types = [self._format_type_name(arg) for arg in type_args]
+                    type_name = f"tuple[{', '.join(types)}]"
+                case _ if origin in {Union, UnionType}:
+                    types = [self._format_type_name(arg) for arg in type_args]
+                    type_name = f"Union[{', '.join(types)}]"
+                case _:
+                    type_name = str(field_type)
         else:
             type_name = str(field_type)
 

--- a/src/dify_plugin/core/documentation/generator.py
+++ b/src/dify_plugin/core/documentation/generator.py
@@ -455,30 +455,33 @@ class SchemaDocumentationGenerator:
             The return value.
         """
         if field_type is None:
-            return "Any"
-
-        if isinstance(field_type, type):
+            type_name = "Any"
+        elif isinstance(field_type, type):
             if issubclass(field_type, (BaseModel, Enum)):
                 # Use schema name if available
                 schema = self._type_to_schema.get(field_type)
                 name = schema.name if schema else field_type.__name__
-                return f"[{name}](#{name.lower()})"
-            return field_type.__name__
-
-        if hasattr(field_type, "__origin__") and hasattr(field_type, "__args__"):
+                type_name = f"[{name}](#{name.lower()})"
+            else:
+                type_name = field_type.__name__
+        elif hasattr(field_type, "__origin__") and hasattr(field_type, "__args__"):
             origin = field_type.__origin__
             if origin in COLLECTION_ORIGINS:
                 inner_type = self._format_type_name(field_type.__args__[0])
-                return f"{origin.__name__}[{inner_type}]"
-            if origin is dict:
+                type_name = f"{origin.__name__}[{inner_type}]"
+            elif origin is dict:
                 key_type = self._format_type_name(field_type.__args__[0])
                 value_type = self._format_type_name(field_type.__args__[1])
-                return f"dict[{key_type}, {value_type}]"
-            if origin is tuple:
+                type_name = f"dict[{key_type}, {value_type}]"
+            elif origin is tuple:
                 types = [self._format_type_name(arg) for arg in field_type.__args__]
-                return f"tuple[{', '.join(types)}]"
-            if origin is Union:
+                type_name = f"tuple[{', '.join(types)}]"
+            elif origin is Union:
                 types = [self._format_type_name(arg) for arg in field_type.__args__]
-                return f"Union[{', '.join(types)}]"
+                type_name = f"Union[{', '.join(types)}]"
+            else:
+                type_name = str(field_type)
+        else:
+            type_name = str(field_type)
 
-        return str(field_type)
+        return type_name

--- a/src/dify_plugin/core/plugin_executor.py
+++ b/src/dify_plugin/core/plugin_executor.py
@@ -917,7 +917,9 @@ class PluginExecutor:  # noqa: PLR0904
         action_instance: DynamicSelectProtocol | None = (
             self._get_dynamic_parameter_action(session=session, data=data)
         )
-        assert action_instance, f"Provider `{data.provider}` not found"
+        if action_instance is None:
+            msg = f"Provider `{data.provider}` not found"
+            raise ValueError(msg)
         return {
             "options": action_instance.fetch_parameter_options(
                 parameter=data.parameter,

--- a/src/dify_plugin/core/server/io_server.py
+++ b/src/dify_plugin/core/server/io_server.py
@@ -132,7 +132,9 @@ class IOServer(ABC):
         """
         send heartbeat to stdout
         """
-        assert self.default_writer
+        if self.default_writer is None:
+            msg = "Default writer is required for heartbeat"
+            raise RuntimeError(msg)
 
         while True:
             # timer

--- a/src/dify_plugin/core/server/serverless/request_reader.py
+++ b/src/dify_plugin/core/server/serverless/request_reader.py
@@ -1,4 +1,5 @@
 import socket
+import sys
 import threading
 import time
 from collections.abc import Generator
@@ -19,7 +20,7 @@ from dify_plugin.core.server.serverless.response_writer import ServerlessRespons
 class ServerlessRequestReader(RequestReader):
     def __init__(
         self,
-        host: str = "0.0.0.0",
+        host: str = "0.0.0.0",  # noqa: S104
         port: int = 8080,
         worker_class: str = "gevent",
         workers: int = 5,
@@ -103,12 +104,15 @@ class ServerlessRequestReader(RequestReader):
 
         if socket.socket is gevent.socket.socket:
             server = WSGIServer((self.host, self.port), self.app)
-            print(
+            sys.stdout.write(
                 "* Serving Flask app "
-                "'dify_plugin.core.server.serverless.request_reader'"
+                "'dify_plugin.core.server.serverless.request_reader'\n"
             )
-            print(f"* Running on http://{self.host}:{self.port} (Press CTRL+C to quit)")
-            print("* Server Worker: gevent.wsgi.WSGIServer", flush=True)
+            sys.stdout.write(
+                f"* Running on http://{self.host}:{self.port} (Press CTRL+C to quit)\n"
+            )
+            sys.stdout.write("* Server Worker: gevent.wsgi.WSGIServer\n")
+            sys.stdout.flush()
             server.serve_forever()
         else:
             self.app.run(host=self.host, port=self.port, threaded=True)

--- a/src/dify_plugin/entities/invoke_message.py
+++ b/src/dify_plugin/entities/invoke_message.py
@@ -131,9 +131,8 @@ class InvokeMessage(BaseModel):
         RETRIEVER_RESOURCES = "retriever_resources"
 
     type: MessageType
-    # TODO: pydantic will validate and construct the message one by one,
-    # until it encounters a correct type
-    # we need to optimize the construction process
+    # Pydantic validates and constructs candidate messages one by one
+    # until a type matches; optimizing this would reduce construction overhead.
     message: (
         TextMessage
         | JsonMessage

--- a/src/dify_plugin/file/file.py
+++ b/src/dify_plugin/file/file.py
@@ -46,5 +46,7 @@ class File(BaseModel):
                 )
                 raise ValueError(msg) from e
 
-        assert self._blob is not None
+        if self._blob is None:
+            msg = f"File URL '{self.url}' returned no content"
+            raise ValueError(msg)
         return self._blob

--- a/src/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/src/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -897,15 +897,21 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
             completion_tokens = usage["completion_tokens"]
         else:
             # calculate num tokens
-            assert prompt_messages[0].content is not None
+            if prompt_messages[0].content is None:
+                msg = "Prompt message content is required"
+                raise ValueError(msg)
+            prompt_content = cast("str", prompt_messages[0].content)
             prompt_tokens = self._num_tokens_from_string(
                 model,
-                prompt_messages[0].content,
+                prompt_content,
             )
-            assert assistant_message.content is not None
+            if assistant_message.content is None:
+                msg = "Assistant message content is required"
+                raise ValueError(msg)
+            assistant_content = cast("str", assistant_message.content)
             completion_tokens = self._num_tokens_from_string(
                 model,
-                assistant_message.content,
+                assistant_content,
             )
 
         # transform usage
@@ -1076,9 +1082,8 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
         return self._get_num_tokens_by_gpt2(str(message_value))
 
     def _text_from_message_value(self, value: object) -> object:
-        # TODO: The current token calculation method for the image type is not
-        # implemented. It needs to download the image and calculate resolution,
-        # which increases request delay.
+        # Image token calculation remains approximate because exact sizing
+        # requires downloading images and measuring resolution.
         if not isinstance(value, list):
             return value
 

--- a/src/dify_plugin/interfaces/model/openai_compatible/rerank.py
+++ b/src/dify_plugin/interfaces/model/openai_compatible/rerank.py
@@ -71,7 +71,7 @@ class OAICompatRerankModel(RerankModel):
             "Content-Type": "application/json",
         }
 
-        # TODO: Do we need truncate docs to avoid llama.cpp return error?
+        # Open question: truncate docs before llama.cpp-compatible requests?
 
         data = {
             "model": credentials.get("endpoint_model_name", model),

--- a/src/dify_plugin/interfaces/model/openai_compatible/text_embedding.py
+++ b/src/dify_plugin/interfaces/model/openai_compatible/text_embedding.py
@@ -84,7 +84,7 @@ class OAICompatEmbeddingModel(_CommonOaiApiCompat, TextEmbeddingModel):
 
         for i, text in enumerate(texts):
             # Here token count is only an approximation based on the GPT2 tokenizer
-            # TODO: Optimize for better token estimation and chunking
+            # Better token estimation would make chunking more precise.
             num_tokens = self._get_num_tokens_by_gpt2(text)
 
             if num_tokens >= context_size:

--- a/src/dify_plugin/interfaces/model/tts_model.py
+++ b/src/dify_plugin/interfaces/model/tts_model.py
@@ -182,7 +182,7 @@ class TTSModel(AIModel):
             result.append(one_sentence)
         return result
 
-    # TODO: To improve the streaming function
+    # Streaming behavior can be improved independently of filename generation.
     @staticmethod
     def _get_file_name(file_content: str) -> str:
         hash_object = hashlib.sha256(file_content.encode())

--- a/src/dify_plugin/interfaces/tool/tool.py
+++ b/src/dify_plugin/interfaces/tool/tool.py
@@ -186,7 +186,9 @@ class ToolLike[T: InvokeMessage](ABC):
         """
         mark log as finished
         """
-        assert isinstance(log.message, InvokeMessage.LogMessage)
+        if not isinstance(log.message, InvokeMessage.LogMessage):
+            msg = "Log message payload is required"
+            raise TypeError(msg)
         return self.response_type(
             type=InvokeMessage.MessageType.LOG,
             message=InvokeMessage.LogMessage(
@@ -423,7 +425,7 @@ class Tool(ToolLike[ToolInvokeMessage]):
             runtime=ToolRuntime(
                 credentials=credentials, user_id=user_id, session_id=None
             ),
-            session=Session.empty_session(),  # TODO: could not fetch session here
+            session=Session.empty_session(),  # Session is unavailable here.
         )
 
     ############################################################

--- a/src/dify_plugin/invocations/model/llm.py
+++ b/src/dify_plugin/invocations/model/llm.py
@@ -84,7 +84,7 @@ class LLMInvocation(BackwardsInvocation[LLMResultChunk]):
             usage=LLMUsage.empty_usage(),
         )
 
-        assert isinstance(result.message.content, str)
+        result.message.content = cast("str", result.message.content)
 
         for llm_result in self._backwards_invoke(
             InvokeType.LLM,

--- a/src/dify_plugin/invocations/model/llm_structured_output.py
+++ b/src/dify_plugin/invocations/model/llm_structured_output.py
@@ -99,7 +99,7 @@ class LLMStructuredOutputInvocation(
             structured_output=None,
         )
 
-        assert isinstance(result.message.content, str)
+        result.message.content = cast("str", result.message.content)
 
         for llm_result in self._backwards_invoke(
             InvokeType.LLMStructuredOutput,

--- a/tests/__mock_server/__main__.py
+++ b/tests/__mock_server/__main__.py
@@ -1,8 +1,11 @@
+import sys
+
 from .openai import openai_server_mock
 
 
 def main() -> None:
-    print("OpenAI mock server starting", flush=True)
+    sys.stdout.write("OpenAI mock server starting\n")
+    sys.stdout.flush()
     openai_server_mock()
 
 


### PR DESCRIPTION
Closes #325

## Summary

- Resolve low-risk Ruff violations and remove their global ignore entries.
- Scope intentional bind-address suppressions locally.
- Preserve behavior while simplifying small return-flow, stdout, assertion, and comment cleanup paths.

## Validation

- `just check`
- `just test` (`78 passed, 1 skipped`)

## Notes

Untracked local directories are intentionally excluded from this PR.
