### PR TITLE
chore: bump package version to 0.8.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ Each example in `examples/` follows a consistent structure:
 
 ## Version Management
 
-- **SDK Version:** Currently 0.8.0 (semantic versioning)
+- **SDK Version:** Currently 0.8.1 (semantic versioning)
 - **Manifest Version:** Plugin compatibility version (currently 0.0.2)
 - **Minimum Dify Version:** Required Dify version for plugin features
 

--- a/README.md
+++ b/README.md
@@ -72,4 +72,4 @@ For the manifest specification, we've introduced two versioning fields:
 | 1.9.0                | 0.5.0         | Support Datasource functionality for plugins       |
 | 1.10.0               | 0.6.0         | Support Trigger functionality for plugins          |
 | 1.11.0               | 0.7.0         | Support Multimodal Reranking / Embeddings          |
-| 1.14.0               | 0.8.0         | Dependency and project structure cleanup           |
+| 1.14.0               | 0.8.1         | Dependency and project structure cleanup           |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = 'dify_plugin'
-version = '0.8.0'
+version = '0.8.1'
 description = 'Dify Plugin SDK'
 authors = [{ name = 'langgenius', email = 'hello@dify.ai' }]
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -245,7 +245,7 @@ wheels = [
 
 [[package]]
 name = "dify-plugin"
-version = "0.8.0"
+version = "0.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "dpkt" },


### PR DESCRIPTION
## Summary
- Bump package metadata and root lockfile to 0.8.1.
- Update version reference docs for the next release.

## Validation
- just check

Closes #327