### PR TITLE
fix: align package metadata with PyPI name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = 'dify_plugin'
+name = 'dify-plugin'
 version = '0.9.0'
 description = 'Dify Plugin SDK'
 authors = [{ name = 'langgenius', email = 'hello@dify.ai' }]


### PR DESCRIPTION
Closes #336

# Pull Request Checklist

Thank you for your contribution! Before submitting your PR, please make sure you have completed the following checks:

## Compatibility Check

- [x] I have checked whether this change affects the backward compatibility of the plugin declared in README.md
- [x] I have checked whether this change affects the forward compatibility of the plugin declared in README.md
- [x] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the README.md
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [x] I have checked whether the plugin version is updated in the README.md

## Available Checks

- [x] just build has passed
- [x] Relevant documentation has been updated (if necessary)

## Summary

- Change the package metadata name from dify_plugin to dify-plugin.
- Keep the Python import package unchanged as dify_plugin.
- Align the package metadata with the release workflow PyPI project URLs and trusted publisher project naming.

## Compatibility

This changes only the published distribution metadata name. PyPI normalizes dify_plugin and dify-plugin to the same canonical project name, so the import path and installed package usage remain unchanged.

## Validation

- just build passed.
- Verified the generated wheel metadata reports Name: dify-plugin.
- just check was attempted, but the local worktree contains untracked exploratory plugin directories and ruff includes them; the failure is unrelated to this one-file metadata change.