### PR TITLE
fix: reject empty polling plugin state

### DIFF
--- a/src/dify_plugin/core/entities/plugin/request.py
+++ b/src/dify_plugin/core/entities/plugin/request.py
@@ -214,7 +214,7 @@ class ModelCheckPollingRequest(PluginAccessModelRequest):
 
     workflow_run_id: str
     node_id: str
-    plugin_state: dict[str, JsonValue]
+    plugin_state: dict[str, JsonValue] = Field(min_length=1)
 
 
 class ModelGetLLMNumTokens(PluginAccessModelRequest, PromptMessageMixin):

--- a/src/dify_plugin/entities/model/llm.py
+++ b/src/dify_plugin/entities/model/llm.py
@@ -201,7 +201,7 @@ class LLMPollingResult(BaseModel):
 
     @model_validator(mode="after")
     def validate_status_payload(self) -> "LLMPollingResult":
-        if self.status == LLMPollingStatus.RUNNING and self.plugin_state is None:
+        if self.status == LLMPollingStatus.RUNNING and not self.plugin_state:
             msg = "plugin_state is required when polling status is running."
             raise ValueError(msg)
 

--- a/tests/test_model_polling.py
+++ b/tests/test_model_polling.py
@@ -291,6 +291,23 @@ def test_start_polling_request_rejects_streaming() -> None:
         )
 
 
+def test_check_polling_request_rejects_empty_plugin_state() -> None:
+    scenario = PollingScenario()
+    data: dict[str, object] = {
+        "user_id": scenario.user_id,
+        "provider": scenario.provider,
+        "model_type": ModelType.LLM,
+        "model": scenario.model,
+        "credentials": scenario.credentials,
+        "workflow_run_id": scenario.workflow_run_id,
+        "node_id": scenario.node_id,
+        "plugin_state": {},
+    }
+
+    with pytest.raises(ValueError, match="at least 1 item"):
+        ModelCheckPollingRequest(**data)
+
+
 def test_executor_starts_llm_polling() -> None:
     scenario = PollingScenario()
     model = PollingLLM(scenario)
@@ -353,6 +370,9 @@ def test_executor_rejects_llm_without_polling_feature() -> None:
 def test_polling_result_validates_state_payloads() -> None:
     with pytest.raises(ValueError, match="plugin_state is required"):
         LLMPollingResult(status=LLMPollingStatus.RUNNING)
+
+    with pytest.raises(ValueError, match="plugin_state is required"):
+        LLMPollingResult(status=LLMPollingStatus.RUNNING, plugin_state={})
 
     with pytest.raises(ValueError, match="result is required"):
         LLMPollingResult(status=LLMPollingStatus.SUCCEEDED)

--- a/tests/test_model_polling.py
+++ b/tests/test_model_polling.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 import pytest
-from pydantic import JsonValue
+from pydantic import JsonValue, ValidationError
 
 from dify_plugin.config.config import DifyPluginEnv
 from dify_plugin.core.entities.plugin.request import (
@@ -284,7 +284,7 @@ def test_polling_requests_parse_daemon_payloads() -> None:
 def test_start_polling_request_rejects_streaming() -> None:
     scenario = PollingScenario()
 
-    with pytest.raises(ValueError, match="Input should be False"):
+    with pytest.raises(ValidationError, match="Input should be False"):
         scenario.start_request(
             prompt_messages=scenario.daemon_prompt_messages,
             stream=True,
@@ -304,7 +304,7 @@ def test_check_polling_request_rejects_empty_plugin_state() -> None:
         "plugin_state": {},
     }
 
-    with pytest.raises(ValueError, match="at least 1 item"):
+    with pytest.raises(ValidationError, match="at least 1 item"):
         ModelCheckPollingRequest(**data)
 
 
@@ -368,16 +368,16 @@ def test_executor_rejects_llm_without_polling_feature() -> None:
 
 
 def test_polling_result_validates_state_payloads() -> None:
-    with pytest.raises(ValueError, match="plugin_state is required"):
+    with pytest.raises(ValidationError, match="plugin_state is required"):
         LLMPollingResult(status=LLMPollingStatus.RUNNING)
 
-    with pytest.raises(ValueError, match="plugin_state is required"):
+    with pytest.raises(ValidationError, match="plugin_state is required"):
         LLMPollingResult(status=LLMPollingStatus.RUNNING, plugin_state={})
 
-    with pytest.raises(ValueError, match="result is required"):
+    with pytest.raises(ValidationError, match="result is required"):
         LLMPollingResult(status=LLMPollingStatus.SUCCEEDED)
 
-    with pytest.raises(ValueError, match="error is required"):
+    with pytest.raises(ValidationError, match="error is required"):
         LLMPollingResult(status=LLMPollingStatus.FAILED)
 
 
@@ -388,7 +388,7 @@ def test_polling_result_validates_state_payloads() -> None:
 def test_polling_result_rejects_non_positive_limits(field_name: str) -> None:
     scenario = PollingScenario()
 
-    with pytest.raises(ValueError, match="Input should be greater than 0"):
+    with pytest.raises(ValidationError, match="Input should be greater than 0"):
         LLMPollingResult(
             status=LLMPollingStatus.RUNNING,
             plugin_state=scenario.plugin_state,


### PR DESCRIPTION
## Summary

- Require `ModelCheckPollingRequest.plugin_state` to contain at least one item.
- Treat empty `plugin_state` as invalid for running LLM polling results.
- Add tests for empty request and result state payloads.

## Root cause

The existing validation only rejected a missing state payload. Empty mappings could pass even though polling cannot resume with no stored state.

## Validation

- `uv run pytest tests/test_model_polling.py`
- `just check`

Closes #341
