### PR TITLE
feat(agent): name the dropped tool when _init_prompt_tools swallows a conversion exception

### DIFF
--- a/src/dify_plugin/interfaces/agent/strategy.py
+++ b/src/dify_plugin/interfaces/agent/strategy.py
@@ -286,8 +286,20 @@ class AgentStrategy(ToolLike[AgentInvokeMessage]):
             try:
                 prompt_tool = self._convert_tool_to_prompt_message_tool(tool)
             except Exception:
-                # api tool may be deleted
-                logger.exception("Failed to convert tool to prompt message tool")
+                # api tool may be deleted (e.g. its provider was recreated and
+                # the app's stored provider_id no longer matches any row in
+                # tool_api_providers). Naming the tool lets operators grep for
+                # the drop in plugin_daemon logs instead of guessing why the
+                # model can't see it.
+                tool_name = getattr(
+                    getattr(tool, "identity", None), "name", "<unknown>"
+                )
+                logger.warning(
+                    "Dropping tool %r from prompt: conversion failed "
+                    "(provider may be deleted or its schema is stale)",
+                    tool_name,
+                    exc_info=True,
+                )
                 continue
 
             # save prompt tool


### PR DESCRIPTION
## What

When `_convert_tool_to_prompt_message_tool` raises inside `_init_prompt_tools`, the tool gets silently dropped from the LLM payload and the only trace is `Failed to convert tool to prompt message tool` — which doesn't name the tool. Operators trying to diagnose "why isn't my agent calling X anymore" have no log to grep for.

This PR adds the tool name to the log message and bumps the level from `exception` (ERROR) to `warning`, since `plugin_daemon` routes ERROR through a debug stream by default. No behaviour change beyond observability.

## Why this matters

Burned a couple hours this week on the symptom. A custom API tool provider was recreated at some point — same name, new UUID in `tool_api_providers`. Every existing app's `agent_mode.tools[*].provider_id` still pointed at the prior UUID. `App.deleted_tools` (in `langgenius/dify` at `models/model.py`) joined on the stale IDs, marked the tools deleted, and `_init_prompt_tools` here dropped them. The LLM saw a partial tools list and either shortcut-synthesized or returned its own "unknown tool" rejection in-stream. Reading the wire-level capture made it obvious; the existing log alone wouldn't have.

The longer-term fix is probably either (a) a Dify-side migration that rewires stored `provider_id` references when a provider is recreated under the same name, or (b) refusing the recreate when dependent apps exist. Both are larger changes that belong in `langgenius/dify`. This PR is the small observability fix that would have shortened my session today.

## Diff

```diff
-            except Exception:
-                # api tool may be deleted
-                logger.exception("Failed to convert tool to prompt message tool")
+            except Exception:
+                # api tool may be deleted (e.g. its provider was recreated and
+                # the app's stored provider_id no longer matches any row in
+                # tool_api_providers). Naming the tool lets operators grep for
+                # the drop in plugin_daemon logs instead of guessing why the
+                # model can't see it.
+                tool_name = getattr(
+                    getattr(tool, "identity", None), "name", "<unknown>"
+                )
+                logger.warning(
+                    "Dropping tool %r from prompt: conversion failed "
+                    "(provider may be deleted or its schema is stale)",
+                    tool_name,
+                    exc_info=True,
+                )
                 continue
```

## Compatibility Check

- [x] Backward compatible — log line change only, no API change
- [x] Forward compatible
- [x] No breaking change
- [x] No version bump needed — observability-only fix

## Available Checks

- [ ] `just build` — haven't run it locally; happy to iterate if CI flags anything

—

I'm grateful for this project's efforts and appreciate the chance to help evolve/improve it.
