### PR TITLE
fix(speech2text): preserve recognized audio suffixes

### DIFF
--- a/src/dify_plugin/core/plugin_executor.py
+++ b/src/dify_plugin/core/plugin_executor.py
@@ -1,5 +1,4 @@
 import binascii
-import pathlib
 import tempfile
 from collections.abc import Generator, Iterable, Mapping
 from typing import TYPE_CHECKING, Any
@@ -91,6 +90,70 @@ if TYPE_CHECKING:
     from dify_plugin.interfaces.datasource import DatasourceProvider
     from dify_plugin.interfaces.endpoint import Endpoint
     from dify_plugin.interfaces.tool import Tool
+
+_EBML_MAX_ID_WIDTH = 4
+_EBML_MAX_SIZE_WIDTH = 8
+
+
+def _read_ebml_size(data: bytes, offset: int) -> tuple[int, int] | None:
+    if offset >= len(data):
+        return None
+    width = 9 - data[offset].bit_length()
+    if width > _EBML_MAX_SIZE_WIDTH or offset + width > len(data):
+        return None
+    value = int.from_bytes(data[offset : offset + width]) & ((1 << (7 * width)) - 1)
+    if value == (1 << (7 * width)) - 1:
+        return None
+    return value, offset + width
+
+
+def _is_webm_header(header: bytes) -> bool:
+    if not header.startswith(b"\x1a\x45\xdf\xa3"):
+        return False
+    root = _read_ebml_size(header, 4)
+    if root is None:
+        return False
+    root_size, offset = root
+    root_end = offset + root_size
+    while offset < root_end:
+        if offset >= len(header):
+            break
+        id_width = 9 - header[offset].bit_length()
+        if id_width > _EBML_MAX_ID_WIDTH or offset + id_width > min(
+            root_end, len(header)
+        ):
+            break
+        element_id = header[offset : offset + id_width]
+        element = _read_ebml_size(header, offset + id_width)
+        if element is None:
+            break
+        element_size, value_start = element
+        value_end = value_start + element_size
+        if value_end > root_end or value_end > len(header):
+            break
+        if element_id == b"\x42\x82":
+            return header[value_start:value_end].partition(b"\0")[0] == b"webm"
+        offset = value_end
+    return False
+
+
+def _detect_audio_suffix(header: bytes) -> str:
+    """Select an upload suffix from recognizable audio container headers."""
+    suffix = ".mp3"
+    if header[:4] == b"RIFF" and header[8:12] == b"WAVE":
+        suffix = ".wav"
+    elif header.startswith(b"fLaC"):
+        suffix = ".flac"
+    elif header.startswith(b"OggS"):
+        suffix = ".ogg"
+    elif header[4:8] == b"ftyp":
+        if header[8:12] == b"M4A ":
+            suffix = ".m4a"
+        elif header[8:12] in {b"isom", b"iso2", b"mp41", b"mp42"}:
+            suffix = ".mp4"
+    elif _is_webm_header(header):
+        suffix = ".webm"
+    return suffix
 
 
 class PluginExecutor:  # ruff:ignore[too-many-public-methods]
@@ -541,27 +604,26 @@ class PluginExecutor:  # ruff:ignore[too-many-public-methods]
             data.model_type,
         )
 
-        with tempfile.NamedTemporaryFile(suffix=".mp3", mode="wb", delete=True) as temp:
-            temp.write(binascii.unhexlify(data.file))
+        audio = binascii.unhexlify(data.file)
+        suffix = _detect_audio_suffix(audio[:8192])
+        with tempfile.NamedTemporaryFile(suffix=suffix, mode="w+b") as temp:
+            temp.write(audio)
+            del audio
             temp.flush()
-
-            with pathlib.Path(temp.name).open("rb") as f:
-                if isinstance(model_instance, Speech2TextModel):
-                    with use_current_session(session):
-                        result = model_instance.invoke(
-                            data.model,
-                            data.credentials,
-                            f,
-                            data.user_id,
-                        )
-                    return {"result": result}
-                msg = (
-                    f"Model `{data.model_type}` not found for provider "
-                    f"`{data.provider}`"
-                )
-                raise ValueError(
-                    msg,
-                )
+            temp.seek(0)
+            if isinstance(model_instance, Speech2TextModel):
+                with use_current_session(session):
+                    result = model_instance.invoke(
+                        data.model,
+                        data.credentials,
+                        temp.file,
+                        data.user_id,
+                    )
+                return {"result": result}
+            msg = f"Model `{data.model_type}` not found for provider `{data.provider}`"
+            raise ValueError(
+                msg,
+            )
 
     def get_ai_model_schemas(
         self,

--- a/tests/core/test_invoke_speech_to_text.py
+++ b/tests/core/test_invoke_speech_to_text.py
@@ -1,0 +1,81 @@
+import binascii
+import io
+import pathlib
+from typing import IO
+from unittest.mock import MagicMock
+
+import pytest
+
+from dify_plugin.core.entities.plugin.request import ModelInvokeSpeech2TextRequest
+from dify_plugin.core.plugin_executor import PluginExecutor
+from dify_plugin.core.runtime import Session
+from dify_plugin.entities.model import ModelType
+from dify_plugin.interfaces.model.speech2text_model import Speech2TextModel
+
+
+@pytest.mark.parametrize(
+    ("audio", "expected_suffix"),
+    [
+        (b"RIFF\x24\x08\x00\x00WAVEpayload", ".wav"),
+        (b"fLaCpayload", ".flac"),
+        (b"OggSpayload", ".ogg"),
+        (b"\x00\x00\x00\x18ftypM4A payload", ".m4a"),
+        (b"\x00\x00\x00\x18ftypmp42payload", ".mp4"),
+        (
+            bytes.fromhex(
+                "1a45dfa39f4286810142f7810142f2810442f38108"
+                "4282847765626d4287810242858102"
+            ),
+            ".webm",
+        ),
+        (b"\x1a\x45\xdf\xa3\x88\x42\x82\x40\x04webm", ".webm"),
+        (b"\x1a\x45\xdf\xa3\x88\x42\x82\x85webm\0", ".webm"),
+        (b"RIFF\x24\x08\x00\x00AVI payload", ".mp3"),
+        (b"\x00\x00\x00\x18ftypavifpayload", ".mp3"),
+        (b"\x1a\x45\xdf\xa3\x9f\x42\x82\x88matroskapayload", ".mp3"),
+        (
+            b"\x1a\x45\xdf\xa3\x8b\x42\x82\x88matroska\x42\x82\x84webm",
+            ".mp3",
+        ),
+        (
+            b"\x1a\x45\xdf\xa3\x94\xec\x87\x42\x82\x84webm\x42\x82\x88matroska",
+            ".mp3",
+        ),
+        (b"ID3payload", ".mp3"),
+        (b"", ".mp3"),
+    ],
+)
+def test_invoke_speech_to_text_preserves_audio_format(
+    audio: bytes,
+    expected_suffix: str,
+) -> None:
+    def invoke(
+        model_name: str,
+        credentials: dict[str, object],
+        audio_file: IO[bytes],
+        user_id: str | None,
+    ) -> str:
+        del model_name, credentials, user_id
+        assert isinstance(audio_file, io.IOBase)
+        assert pathlib.Path(audio_file.name).suffix == expected_suffix
+        assert audio_file.tell() == 0
+        assert audio_file.read() == audio
+        return "transcript"
+
+    model = MagicMock(spec=Speech2TextModel)
+    model.invoke.side_effect = invoke
+    registration = MagicMock()
+    registration.get_model_instance.return_value = model
+    executor = PluginExecutor(config=MagicMock(), registration=registration)
+    request = ModelInvokeSpeech2TextRequest(
+        user_id="user",
+        provider="provider",
+        model_type=ModelType.SPEECH2TEXT,
+        model="model",
+        credentials={},
+        file=binascii.hexlify(audio).decode(),
+    )
+
+    assert executor.invoke_speech_to_text(Session.empty_session(), request) == {
+        "result": "transcript",
+    }


### PR DESCRIPTION
Closes #347

## Summary

Preserve recognizable audio container suffixes when the shared speech-to-text dispatcher creates the provider upload stream.

The protocol only carries audio bytes, so this uses conservative header signatures and keeps `.mp3` as the fallback for unknown or ambiguous input.

The implementation also reuses the underlying temporary file instead of reopening an active `NamedTemporaryFile` by path.

## Changes

- Detect WAV, FLAC, Ogg, M4A, common MP4, and WebM container headers.
- Distinguish common MP4 brands from M4A and require the WebM EBML `DocType`.
- Decode the payload once, rewind the temporary stream, and pass its underlying `IOBase` file to the model.
- Add one focused parameterized test for recognized formats, false positives, fallback behavior, filename suffixes, stream position, and payload integrity.

## Safety and compatibility

The selected suffix is only a multipart filename hint, and providers remain responsible for validating the actual media content.

Existing MP3 and unknown-input behavior remains unchanged.

Only recognizable non-MP3 inputs that were previously mislabeled are affected.

No public SDK API, request schema, manifest, or dependency changes are introduced.

## Verification

- `uv run pytest tests/core/test_invoke_speech_to_text.py -q`
- `just check`
- `just test`
