### PR TITLE
refactor(model)!: remove obsolete llm polling context fields

### DIFF
--- a/src/dify_plugin/core/entities/plugin/request.py
+++ b/src/dify_plugin/core/entities/plugin/request.py
@@ -205,15 +205,10 @@ class ModelStartPollingRequest(ModelInvokeLLMRequest):
     action: ModelActions = ModelActions.StartPolling
     stream: Literal[False] = False
 
-    workflow_run_id: str
-    node_id: str
-
 
 class ModelCheckPollingRequest(PluginAccessModelRequest):
     action: ModelActions = ModelActions.CheckPolling
 
-    workflow_run_id: str
-    node_id: str
     plugin_state: dict[str, JsonValue] = Field(min_length=1)
 
 

--- a/src/dify_plugin/core/plugin_executor.py
+++ b/src/dify_plugin/core/plugin_executor.py
@@ -296,8 +296,6 @@ class PluginExecutor:  # noqa: PLR0904
             stream=data.stream,
             user=data.user_id,
             json_schema=data.json_schema,
-            workflow_run_id=data.workflow_run_id,
-            node_id=data.node_id,
         )
 
     def check_llm_polling(
@@ -328,8 +326,6 @@ class PluginExecutor:  # noqa: PLR0904
             credentials=data.credentials,
             plugin_state=data.plugin_state,
             user=data.user_id,
-            workflow_run_id=data.workflow_run_id,
-            node_id=data.node_id,
         )
 
     def get_llm_num_tokens(

--- a/src/dify_plugin/interfaces/model/large_language_model.py
+++ b/src/dify_plugin/interfaces/model/large_language_model.py
@@ -32,14 +32,12 @@ from dify_plugin.entities.model.message import (
     SystemPromptMessage,
     UserPromptMessage,
 )
-from dify_plugin.errors.model import InvokeError
 from dify_plugin.interfaces.model.ai_model import AIModel
 
 logger = logging.getLogger(__name__)
 
 CODE_FENCE_BACKTICK_COUNT = 3
 STRUCTURED_RESPONSE_FORMATS = frozenset({"JSON", "XML"})
-OBSOLETE_POLLING_CONTEXT_PARAMETERS = frozenset({"workflow_run_id", "node_id"})
 
 
 class LargeLanguageModel(AIModel):
@@ -203,27 +201,6 @@ class LargeLanguageModel(AIModel):
         )
 
         return has_feature and has_methods
-
-    def _raise_if_polling_interface_outdated(self) -> None:
-        outdated_methods: list[str] = []
-        for method_name in ("_start_polling", "_check_polling"):
-            parameters = inspect.signature(getattr(type(self), method_name)).parameters
-            if OBSOLETE_POLLING_CONTEXT_PARAMETERS.intersection(parameters):
-                outdated_methods.append(method_name)
-
-        if not outdated_methods:
-            return
-
-        outdated_method_list = ", ".join(
-            f"`{method_name}`" for method_name in outdated_methods
-        )
-        raise InvokeError(
-            description=(
-                "Outdated polling interface detected. Remove `workflow_run_id` "
-                f"and `node_id` from {outdated_method_list} to match the current "
-                "SDK polling contract."
-            )
-        )
 
     def _calc_response_usage(
         self,
@@ -790,7 +767,6 @@ class LargeLanguageModel(AIModel):
         if not self.supports_polling(model, credentials):
             msg = f"Model `{model}` does not support polling."
             raise NotImplementedError(msg)
-        self._raise_if_polling_interface_outdated()
 
         if model_parameters is None:
             model_parameters = {}
@@ -828,7 +804,6 @@ class LargeLanguageModel(AIModel):
         if not self.supports_polling(model, credentials):
             msg = f"Model `{model}` does not support polling."
             raise NotImplementedError(msg)
-        self._raise_if_polling_interface_outdated()
 
         with self.timing_context():
             try:

--- a/src/dify_plugin/interfaces/model/large_language_model.py
+++ b/src/dify_plugin/interfaces/model/large_language_model.py
@@ -32,12 +32,14 @@ from dify_plugin.entities.model.message import (
     SystemPromptMessage,
     UserPromptMessage,
 )
+from dify_plugin.errors.model import InvokeError
 from dify_plugin.interfaces.model.ai_model import AIModel
 
 logger = logging.getLogger(__name__)
 
 CODE_FENCE_BACKTICK_COUNT = 3
 STRUCTURED_RESPONSE_FORMATS = frozenset({"JSON", "XML"})
+OBSOLETE_POLLING_CONTEXT_PARAMETERS = frozenset({"workflow_run_id", "node_id"})
 
 
 class LargeLanguageModel(AIModel):
@@ -89,8 +91,6 @@ class LargeLanguageModel(AIModel):
         stream: Literal[False] = False,
         user: str | None = None,
         *,
-        workflow_run_id: str,
-        node_id: str,
         json_schema: dict[str, JsonValue] | None = None,
     ) -> LLMPollingResult:
         """Start a polling-based large language model invocation."""
@@ -103,8 +103,6 @@ class LargeLanguageModel(AIModel):
             stop,
             stream,
             user,
-            workflow_run_id,
-            node_id,
             json_schema,
         )
         raise NotImplementedError
@@ -115,12 +113,9 @@ class LargeLanguageModel(AIModel):
         credentials: dict,
         plugin_state: dict[str, JsonValue],
         user: str | None = None,
-        *,
-        workflow_run_id: str,
-        node_id: str,
     ) -> LLMPollingResult:
         """Check a polling-based large language model invocation."""
-        del model, credentials, plugin_state, user, workflow_run_id, node_id
+        del model, credentials, plugin_state, user
         raise NotImplementedError
 
     @abstractmethod
@@ -208,6 +203,27 @@ class LargeLanguageModel(AIModel):
         )
 
         return has_feature and has_methods
+
+    def _raise_if_polling_interface_outdated(self) -> None:
+        outdated_methods: list[str] = []
+        for method_name in ("_start_polling", "_check_polling"):
+            parameters = inspect.signature(getattr(type(self), method_name)).parameters
+            if OBSOLETE_POLLING_CONTEXT_PARAMETERS.intersection(parameters):
+                outdated_methods.append(method_name)
+
+        if not outdated_methods:
+            return
+
+        outdated_method_list = ", ".join(
+            f"`{method_name}`" for method_name in outdated_methods
+        )
+        raise InvokeError(
+            description=(
+                "Outdated polling interface detected. Remove `workflow_run_id` "
+                f"and `node_id` from {outdated_method_list} to match the current "
+                "SDK polling contract."
+            )
+        )
 
     def _calc_response_usage(
         self,
@@ -769,14 +785,12 @@ class LargeLanguageModel(AIModel):
         stream: Literal[False] = False,
         user: str | None = None,
         json_schema: dict[str, JsonValue] | None = None,
-        *,
-        workflow_run_id: str,
-        node_id: str,
     ) -> LLMPollingResult:
         """Start a polling-based large language model invocation."""
         if not self.supports_polling(model, credentials):
             msg = f"Model `{model}` does not support polling."
             raise NotImplementedError(msg)
+        self._raise_if_polling_interface_outdated()
 
         if model_parameters is None:
             model_parameters = {}
@@ -798,8 +812,6 @@ class LargeLanguageModel(AIModel):
                     stop=stop,
                     stream=stream,
                     user=user,
-                    workflow_run_id=workflow_run_id,
-                    node_id=node_id,
                     json_schema=json_schema,
                 )
             except Exception as e:
@@ -811,14 +823,12 @@ class LargeLanguageModel(AIModel):
         credentials: dict,
         plugin_state: dict[str, JsonValue],
         user: str | None = None,
-        *,
-        workflow_run_id: str,
-        node_id: str,
     ) -> LLMPollingResult:
         """Check a polling-based large language model invocation."""
         if not self.supports_polling(model, credentials):
             msg = f"Model `{model}` does not support polling."
             raise NotImplementedError(msg)
+        self._raise_if_polling_interface_outdated()
 
         with self.timing_context():
             try:
@@ -827,8 +837,6 @@ class LargeLanguageModel(AIModel):
                     credentials=credentials,
                     plugin_state=plugin_state,
                     user=user,
-                    workflow_run_id=workflow_run_id,
-                    node_id=node_id,
                 )
             except Exception as e:
                 raise self._transform_invoke_error(e) from e

--- a/tests/test_model_polling.py
+++ b/tests/test_model_polling.py
@@ -1,3 +1,4 @@
+import inspect
 from collections.abc import Generator, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -38,8 +39,6 @@ class PollingScenario:
     provider: str = "provider"
     model: str = "llm"
     api_key: str = "key"
-    workflow_run_id: str = "wr-1"
-    node_id: str = "node-1"
     job_id: str = "job-1"
     prompt_content: str = "hello"
     result_content: str = "done"
@@ -96,8 +95,6 @@ class PollingScenario:
             "model_parameters": model_parameters or {},
             "stop": [],
             "tools": [],
-            "workflow_run_id": self.workflow_run_id,
-            "node_id": self.node_id,
         }
         if json_schema is not None:
             data["json_schema"] = json_schema
@@ -117,8 +114,6 @@ class PollingScenario:
             "model_type": ModelType.LLM,
             "model": self.model,
             "credentials": self.credentials,
-            "workflow_run_id": self.workflow_run_id,
-            "node_id": self.node_id,
             "plugin_state": plugin_state or self.plugin_state,
         }
         return ModelCheckPollingRequest(**data)
@@ -199,8 +194,6 @@ class PollingLLM(LargeLanguageModel):
         stream: Literal[False] = False,
         user: str | None = None,
         *,
-        workflow_run_id: str,
-        node_id: str,
         json_schema: dict[str, JsonValue] | None = None,
     ) -> LLMPollingResult:
         self.start_call = {
@@ -212,8 +205,6 @@ class PollingLLM(LargeLanguageModel):
             "stop": stop,
             "stream": stream,
             "user": user,
-            "workflow_run_id": workflow_run_id,
-            "node_id": node_id,
             "json_schema": json_schema,
         }
         return LLMPollingResult(
@@ -230,17 +221,12 @@ class PollingLLM(LargeLanguageModel):
         credentials: dict,
         plugin_state: dict[str, JsonValue],
         user: str | None = None,
-        *,
-        workflow_run_id: str,
-        node_id: str,
     ) -> LLMPollingResult:
         self.check_call = {
             "model": model,
             "credentials": credentials,
             "plugin_state": plugin_state,
             "user": user,
-            "workflow_run_id": workflow_run_id,
-            "node_id": node_id,
         }
         return LLMPollingResult(
             status=LLMPollingStatus.SUCCEEDED,
@@ -264,6 +250,54 @@ class NonPollingLLM(PollingLLM):
         self.model_schemas[0].features = []
 
 
+class LegacyPollingLLM(PollingLLM):
+    def _start_polling(
+        self,
+        model: str,
+        credentials: dict,
+        prompt_messages: list[PromptMessage],
+        model_parameters: dict,
+        tools: list[PromptMessageTool] | None = None,
+        stop: list[str] | None = None,
+        stream: Literal[False] = False,
+        user: str | None = None,
+        *,
+        workflow_run_id: str,
+        node_id: str,
+        json_schema: dict[str, JsonValue] | None = None,
+    ) -> LLMPollingResult:
+        del workflow_run_id, node_id
+        return super()._start_polling(
+            model=model,
+            credentials=credentials,
+            prompt_messages=prompt_messages,
+            model_parameters=model_parameters,
+            tools=tools,
+            stop=stop,
+            stream=stream,
+            user=user,
+            json_schema=json_schema,
+        )
+
+    def _check_polling(
+        self,
+        model: str,
+        credentials: dict,
+        plugin_state: dict[str, JsonValue],
+        user: str | None = None,
+        *,
+        workflow_run_id: str,
+        node_id: str,
+    ) -> LLMPollingResult:
+        del workflow_run_id, node_id
+        return super()._check_polling(
+            model=model,
+            credentials=credentials,
+            plugin_state=plugin_state,
+            user=user,
+        )
+
+
 def test_polling_requests_parse_daemon_payloads() -> None:
     scenario = PollingScenario()
 
@@ -275,10 +309,30 @@ def test_polling_requests_parse_daemon_payloads() -> None:
     assert start_request.stream is False
     assert isinstance(start_request.prompt_messages[0], UserPromptMessage)
     assert start_request.json_schema == scenario.json_schema
+    assert "workflow_run_id" not in start_request.model_dump()
+    assert "node_id" not in start_request.model_dump()
 
     check_request = scenario.check_request()
     assert check_request.action == ModelActions.CheckPolling
     assert check_request.plugin_state == scenario.plugin_state
+    assert "workflow_run_id" not in check_request.model_dump()
+    assert "node_id" not in check_request.model_dump()
+
+
+def test_large_language_model_polling_signatures_do_not_expose_obsolete_context() -> (
+    None
+):
+    polling_methods = (
+        LargeLanguageModel._start_polling,
+        LargeLanguageModel._check_polling,
+        LargeLanguageModel.start_polling,
+        LargeLanguageModel.check_polling,
+    )
+
+    for method in polling_methods:
+        parameters = inspect.signature(method).parameters
+        assert "workflow_run_id" not in parameters
+        assert "node_id" not in parameters
 
 
 def test_start_polling_request_rejects_streaming() -> None:
@@ -299,8 +353,6 @@ def test_check_polling_request_rejects_empty_plugin_state() -> None:
         "model_type": ModelType.LLM,
         "model": scenario.model,
         "credentials": scenario.credentials,
-        "workflow_run_id": scenario.workflow_run_id,
-        "node_id": scenario.node_id,
         "plugin_state": {},
     }
 
@@ -329,10 +381,10 @@ def test_executor_starts_llm_polling() -> None:
     assert response.max_attempts == scenario.max_attempts
     assert model.start_call is not None
     assert model.supports_polling(scenario.model, scenario.credentials)
-    assert model.start_call["workflow_run_id"] == scenario.workflow_run_id
-    assert model.start_call["node_id"] == scenario.node_id
     assert model.start_call["json_schema"] == scenario.json_schema
     assert model.start_call["model_parameters"] == {}
+    assert "workflow_run_id" not in model.start_call
+    assert "node_id" not in model.start_call
 
 
 def test_executor_checks_llm_polling() -> None:
@@ -351,8 +403,8 @@ def test_executor_checks_llm_polling() -> None:
     assert response.result.message.content == scenario.result_content
     assert model.check_call is not None
     assert model.check_call["plugin_state"] == scenario.plugin_state
-    assert model.check_call["workflow_run_id"] == scenario.workflow_run_id
-    assert model.check_call["node_id"] == scenario.node_id
+    assert "workflow_run_id" not in model.check_call
+    assert "node_id" not in model.check_call
 
 
 def test_executor_rejects_llm_without_polling_feature() -> None:
@@ -364,6 +416,36 @@ def test_executor_rejects_llm_without_polling_feature() -> None:
         executor.start_llm_polling(
             Session.empty_session(),
             scenario.start_request(),
+        )
+
+
+def test_executor_rejects_legacy_polling_start_signature_with_migration_error() -> None:
+    scenario = PollingScenario()
+    model = LegacyPollingLLM(scenario)
+    executor = PluginExecutor(DifyPluginEnv(), ModelRegistration(model))
+
+    with pytest.raises(
+        InvokeError,
+        match="Remove `workflow_run_id` and `node_id`",
+    ):
+        executor.start_llm_polling(
+            Session.empty_session(),
+            scenario.start_request(),
+        )
+
+
+def test_executor_rejects_legacy_polling_check_signature_with_migration_error() -> None:
+    scenario = PollingScenario()
+    model = LegacyPollingLLM(scenario)
+    executor = PluginExecutor(DifyPluginEnv(), ModelRegistration(model))
+
+    with pytest.raises(
+        InvokeError,
+        match="Remove `workflow_run_id` and `node_id`",
+    ):
+        executor.check_llm_polling(
+            Session.empty_session(),
+            scenario.check_request(),
         )
 
 

--- a/tests/test_model_polling.py
+++ b/tests/test_model_polling.py
@@ -250,54 +250,6 @@ class NonPollingLLM(PollingLLM):
         self.model_schemas[0].features = []
 
 
-class LegacyPollingLLM(PollingLLM):
-    def _start_polling(
-        self,
-        model: str,
-        credentials: dict,
-        prompt_messages: list[PromptMessage],
-        model_parameters: dict,
-        tools: list[PromptMessageTool] | None = None,
-        stop: list[str] | None = None,
-        stream: Literal[False] = False,
-        user: str | None = None,
-        *,
-        workflow_run_id: str,
-        node_id: str,
-        json_schema: dict[str, JsonValue] | None = None,
-    ) -> LLMPollingResult:
-        del workflow_run_id, node_id
-        return super()._start_polling(
-            model=model,
-            credentials=credentials,
-            prompt_messages=prompt_messages,
-            model_parameters=model_parameters,
-            tools=tools,
-            stop=stop,
-            stream=stream,
-            user=user,
-            json_schema=json_schema,
-        )
-
-    def _check_polling(
-        self,
-        model: str,
-        credentials: dict,
-        plugin_state: dict[str, JsonValue],
-        user: str | None = None,
-        *,
-        workflow_run_id: str,
-        node_id: str,
-    ) -> LLMPollingResult:
-        del workflow_run_id, node_id
-        return super()._check_polling(
-            model=model,
-            credentials=credentials,
-            plugin_state=plugin_state,
-            user=user,
-        )
-
-
 def test_polling_requests_parse_daemon_payloads() -> None:
     scenario = PollingScenario()
 
@@ -416,36 +368,6 @@ def test_executor_rejects_llm_without_polling_feature() -> None:
         executor.start_llm_polling(
             Session.empty_session(),
             scenario.start_request(),
-        )
-
-
-def test_executor_rejects_legacy_polling_start_signature_with_migration_error() -> None:
-    scenario = PollingScenario()
-    model = LegacyPollingLLM(scenario)
-    executor = PluginExecutor(DifyPluginEnv(), ModelRegistration(model))
-
-    with pytest.raises(
-        InvokeError,
-        match="Remove `workflow_run_id` and `node_id`",
-    ):
-        executor.start_llm_polling(
-            Session.empty_session(),
-            scenario.start_request(),
-        )
-
-
-def test_executor_rejects_legacy_polling_check_signature_with_migration_error() -> None:
-    scenario = PollingScenario()
-    model = LegacyPollingLLM(scenario)
-    executor = PluginExecutor(DifyPluginEnv(), ModelRegistration(model))
-
-    with pytest.raises(
-        InvokeError,
-        match="Remove `workflow_run_id` and `node_id`",
-    ):
-        executor.check_llm_polling(
-            Session.empty_session(),
-            scenario.check_request(),
         )
 
 

--- a/tests/test_model_polling.py
+++ b/tests/test_model_polling.py
@@ -1,4 +1,3 @@
-import inspect
 from collections.abc import Generator, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal
@@ -269,22 +268,6 @@ def test_polling_requests_parse_daemon_payloads() -> None:
     assert check_request.plugin_state == scenario.plugin_state
     assert "workflow_run_id" not in check_request.model_dump()
     assert "node_id" not in check_request.model_dump()
-
-
-def test_large_language_model_polling_signatures_do_not_expose_obsolete_context() -> (
-    None
-):
-    polling_methods = (
-        LargeLanguageModel._start_polling,
-        LargeLanguageModel._check_polling,
-        LargeLanguageModel.start_polling,
-        LargeLanguageModel.check_polling,
-    )
-
-    for method in polling_methods:
-        parameters = inspect.signature(method).parameters
-        assert "workflow_run_id" not in parameters
-        assert "node_id" not in parameters
 
 
 def test_start_polling_request_rejects_streaming() -> None:


### PR DESCRIPTION
**AI disclosure**: This PR was primarily drafted with Codex using GPT-5.4.
I have reviewed and edited the final diff, and I am responsible for the content.

## Related Issue

Closes #349

## Summary

- remove `workflow_run_id` and `node_id` from the LLM polling daemon request schema
- remove the same obsolete fields from the `LargeLanguageModel` polling method signatures
- stop forwarding those fields in `PluginExecutor`
- add a clear migration guard for legacy polling providers that still implement the old keyword-only parameters
- update polling tests to cover the narrowed contract and the legacy-signature failure mode

## Compatibility Impact

This is a breaking API change for plugin authors who implement polling-capable `LargeLanguageModel` providers against the SDK. Existing implementations must remove `workflow_run_id` and `node_id` from `_start_polling` and `_check_polling` before upgrading.

Target release: the next incompatible SDK release after 0.9.0. The exact version number is still to be decided by maintainers.

## Validation

- `uv run pytest tests/test_model_polling.py -q`
- `just check`
- `just build`
- `just test` still reports the pre-existing integration environment error in `tests/integration/test_invoke_llm.py::test_invoke_llm`, where `python -m tests.__mock_server` fails with `ModuleNotFoundError: No module named 'tests'` in this worktree\n\n# Pull Request Checklist\n\n## Compatibility Check\n\n- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`\n- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`\n- [ ] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`\n- [ ] I have described the compatibility impact and the corresponding version number in the PR description\n- [x] I have checked whether the plugin version is updated in the `README.md`\n\n## Available Checks\n\n- [x] `just build` has passed\n- [x] Relevant documentation has been updated (if necessary)