### PR TITLE
fix(model): pass extra headers during credential validation

### DIFF
--- a/src/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/src/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -194,6 +194,12 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
         response: requests.Response | None = None
         try:
             headers = {"Content-Type": "application/json"}
+            extra_headers = credentials.get("extra_headers")
+            if extra_headers is not None:
+                headers = {
+                    **headers,
+                    **extra_headers,
+                }
 
             api_key = credentials.get("api_key")
             if api_key:

--- a/tests/interfaces/model/openai_compatible/test_llm.py
+++ b/tests/interfaces/model/openai_compatible/test_llm.py
@@ -1,0 +1,45 @@
+from http import HTTPStatus
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dify_plugin.interfaces.model.openai_compatible.llm import (
+    OAICompatLargeLanguageModel,
+)
+
+
+@pytest.mark.parametrize(
+    ("stream_mode_auth", "stream"),
+    [("not_use", False), ("use", True)],
+)
+def test_validate_credentials_passes_extra_headers(
+    stream_mode_auth: str,
+    stream: bool,
+) -> None:
+    response = MagicMock(status_code=HTTPStatus.OK)
+    response.json.return_value = {"object": "chat.completion"}
+    api_key = str(123)
+    credentials = {
+        "api_key": api_key,
+        "endpoint_url": "https://example.com/v1",
+        "extra_headers": {
+            "Authorization": str(456),
+            "Content-Type": "application/custom+json",
+            "X-Api-Key": str(789),
+        },
+        "mode": "chat",
+        "stream_mode_auth": stream_mode_auth,
+    }
+
+    with patch(
+        "dify_plugin.interfaces.model.openai_compatible.llm.requests.post",
+        return_value=response,
+    ) as post:
+        OAICompatLargeLanguageModel([]).validate_credentials("model", credentials)
+
+    assert post.call_args.kwargs["headers"] == {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/custom+json",
+        "X-Api-Key": str(789),
+    }
+    assert post.call_args.kwargs.get("stream", False) is stream


### PR DESCRIPTION
## Summary

- Pass `extra_headers` to OpenAI-compatible LLM credential validation requests.
- Preserve the existing header precedence: defaults, custom headers, then API-key authorization.
- Cover both standard and streaming credential validation.

Fixes #155.

This supersedes the unmerged change proposed in #279.

## Compatibility

This is backward-compatible when `extra_headers` is absent.

No SDK version, plugin version, README, or documentation update is required.

## Tests

- `just check`
- `just test` (`99 passed`, `1 skipped`)
- `just build`

# Pull Request Checklist

## Compatibility Check

- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`.
- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`.
- [x] I have confirmed this change does not introduce a breaking change.
- [x] I have described the compatibility impact and the corresponding version requirements in the PR description.
- [x] I have checked whether the plugin version is updated in `README.md`; no update is required.

## Available Checks

- [x] `just build` has passed.
- [x] Relevant documentation has been updated; no documentation change is necessary.
