### PR TITLE
fix(model): preserve reasoning across empty deltas

### DIFF
--- a/src/dify_plugin/interfaces/model/large_language_model.py
+++ b/src/dify_plugin/interfaces/model/large_language_model.py
@@ -737,12 +737,10 @@ class LargeLanguageModel(AIModel):
                 is_reasoning = True
             else:
                 output = reasoning_content
-        elif is_reasoning and (
-            content
-            or delta.get("tool_calls")
-            or delta.get("function_call")
-            or all(delta.get(key) is None for key in ("reasoning_content", "reasoning"))
-        ):
+            if content or delta.get("tool_calls") or delta.get("function_call"):
+                is_reasoning = False
+                output += "\n</think>" + content
+        elif is_reasoning:
             is_reasoning = False
             output = "\n</think>" + content
 

--- a/src/dify_plugin/interfaces/model/large_language_model.py
+++ b/src/dify_plugin/interfaces/model/large_language_model.py
@@ -737,12 +737,14 @@ class LargeLanguageModel(AIModel):
                 is_reasoning = True
             else:
                 output = reasoning_content
-        elif is_reasoning:
+        elif is_reasoning and (
+            content
+            or delta.get("tool_calls")
+            or delta.get("function_call")
+            or all(delta.get(key) is None for key in ("reasoning_content", "reasoning"))
+        ):
             is_reasoning = False
-            if not reasoning_content:
-                output = "\n</think>"
-            if content:
-                output += content
+            output = "\n</think>" + content
 
         return output, is_reasoning
 

--- a/src/dify_plugin/interfaces/model/openai_compatible/llm.py
+++ b/src/dify_plugin/interfaces/model/openai_compatible/llm.py
@@ -717,16 +717,7 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                     )
                 # stream ended
                 except ValidationError:
-                    yield self._create_final_llm_result_chunk(
-                        index=chunk_index + 1,
-                        message=AssistantPromptMessage(content=""),
-                        finish_reason="Non-JSON encountered.",
-                        usage=usage,
-                        model=model,
-                        credentials=credentials,
-                        prompt_messages=prompt_messages,
-                        full_content=full_assistant_content,
-                    )
+                    finish_reason = "Non-JSON encountered."
                     break
                 # handle the error here. for issue #11629
                 if chunk_json.get("error") and chunk_json.get("choices") is None:
@@ -743,12 +734,27 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
 
                 if "delta" in choice:
                     delta = choice["delta"]
-                    delta_content, is_reasoning_started = (
-                        self._wrap_thinking_by_reasoning_content(
-                            delta,
-                            is_reasoning_started,
-                        )
+                    reasoning_parts = (
+                        delta.get("reasoning_content"),
+                        delta.get("reasoning"),
                     )
+                    if (
+                        is_reasoning_started
+                        and "" in reasoning_parts
+                        and not any(reasoning_parts)
+                        and not any(
+                            delta.get(key)
+                            for key in ("content", "tool_calls", "function_call")
+                        )
+                    ):
+                        delta_content = ""
+                    else:
+                        delta_content, is_reasoning_started = (
+                            self._wrap_thinking_by_reasoning_content(
+                                delta,
+                                is_reasoning_started,
+                            )
+                        )
 
                     assistant_message_tool_calls = None
 
@@ -808,6 +814,18 @@ class OAICompatLargeLanguageModel(_CommonOaiApiCompat, LargeLanguageModel):
                     ),
                 )
 
+            chunk_index += 1
+
+        if is_reasoning_started:
+            closing_content = "\n</think>"
+            full_assistant_content += closing_content
+            yield LLMResultChunk(
+                model=model,
+                delta=LLMResultChunkDelta(
+                    index=chunk_index,
+                    message=AssistantPromptMessage(content=closing_content),
+                ),
+            )
             chunk_index += 1
 
         if tools_calls:

--- a/tests/interfaces/model/openai_compatible/test_llm.py
+++ b/tests/interfaces/model/openai_compatible/test_llm.py
@@ -1,3 +1,4 @@
+import json
 from collections import UserDict
 from collections.abc import Mapping
 from http import HTTPStatus
@@ -5,6 +6,7 @@ from unittest.mock import MagicMock, PropertyMock, patch
 
 import pytest
 
+from dify_plugin.entities.model.llm import LLMResultChunk
 from dify_plugin.errors.model import CredentialsValidateFailedError
 from dify_plugin.interfaces.model.openai_compatible.llm import (
     OAICompatLargeLanguageModel,
@@ -38,6 +40,12 @@ class StatefulTruth:
     def __bool__(self) -> bool:
         self.calls += 1
         return self.calls == 1
+
+
+def _stream_choice(delta: dict, finish_reason: str | None = None) -> str:
+    return "data: " + json.dumps({
+        "choices": [{"delta": delta, "finish_reason": finish_reason}]
+    })
 
 
 @pytest.mark.parametrize(
@@ -323,3 +331,119 @@ def test_validate_credentials_truth_tests_stream_mode_once() -> None:
     assert stream_result.calls == 1
     assert post.call_args.kwargs["stream"] is True
     response.json.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("lines", "expected_content", "expected_finish_reason", "expected_usage"),
+    [
+        (
+            [
+                _stream_choice({"reasoning_content": "A"}),
+                _stream_choice({"reasoning_content": ""}, "stop"),
+                (
+                    'data: {"choices":[],"usage":'
+                    '{"prompt_tokens":1,"completion_tokens":1}}'
+                ),
+                "data: [DONE]",
+            ],
+            "<think>\nA\n</think>",
+            "stop",
+            {"prompt_tokens": 1, "completion_tokens": 1},
+        ),
+        (
+            [
+                _stream_choice({"reasoning_content": "A"}, "stop"),
+                _stream_choice({"reasoning_content": ""}, "stop"),
+                _stream_choice({"reasoning": "B"}, "stop"),
+                _stream_choice({"reasoning": ""}, "stop"),
+                _stream_choice(
+                    {"reasoning_content": "", "reasoning": ""},
+                    "stop",
+                ),
+                _stream_choice({"reasoning_content": "C"}, "stop"),
+                _stream_choice(
+                    {"reasoning_content": "", "content": "Answer"},
+                    "stop",
+                ),
+                "data: [DONE]",
+            ],
+            "<think>\nABC\n</think>Answer",
+            "stop",
+            None,
+        ),
+        (
+            [
+                _stream_choice({"reasoning_content": "A"}),
+                "data: not-json",
+            ],
+            "<think>\nA\n</think>",
+            "Non-JSON encountered.",
+            None,
+        ),
+        (
+            [
+                _stream_choice({"reasoning_content": "A"}),
+                _stream_choice({"reasoning_content": None}),
+                _stream_choice({"reasoning_content": "B"}),
+                _stream_choice({}),
+                _stream_choice({"reasoning_content": "C"}),
+                _stream_choice({
+                    "reasoning_content": "",
+                    "tool_calls": [{"id": "call"}],
+                }),
+                _stream_choice({"reasoning_content": "D"}),
+                _stream_choice({
+                    "reasoning_content": "",
+                    "function_call": {"name": "call"},
+                }),
+                _stream_choice({"reasoning_content": "E"}),
+                "data: [DONE]",
+            ],
+            (
+                "<think>\nA\n</think><think>\nB\n</think>"
+                "<think>\nC\n</think><think>\nD\n</think>"
+                "<think>\nE\n</think>"
+            ),
+            None,
+            None,
+        ),
+    ],
+)
+def test_stream_reasoning_is_closed_at_end(
+    lines: list[str],
+    expected_content: str,
+    expected_finish_reason: str | None,
+    expected_usage: dict | None,
+) -> None:
+    response = MagicMock()
+    response.iter_lines.return_value = lines
+    llm = OAICompatLargeLanguageModel([])
+    final_chunk = object()
+
+    with patch.object(
+        llm,
+        "_create_final_llm_result_chunk",
+        return_value=final_chunk,
+    ) as create_final:
+        results = list(
+            llm._handle_generate_stream_response(
+                model="model",
+                credentials={},
+                response=response,
+                prompt_messages=[],
+            )
+        )
+
+    stream_chunks = [result for result in results if isinstance(result, LLMResultChunk)]
+    assert "".join(chunk.delta.message.content for chunk in stream_chunks) == (
+        expected_content
+    )
+    assert [chunk.delta.index for chunk in stream_chunks] == sorted(
+        chunk.delta.index for chunk in stream_chunks
+    )
+    assert results[-1] is final_chunk
+    create_final.assert_called_once()
+    assert create_final.call_args.kwargs["full_content"] == expected_content
+    assert create_final.call_args.kwargs["finish_reason"] == expected_finish_reason
+    assert create_final.call_args.kwargs["usage"] == expected_usage
+    assert create_final.call_args.kwargs["index"] > stream_chunks[-1].delta.index

--- a/tests/interfaces/model/test_wrap_think.py
+++ b/tests/interfaces/model/test_wrap_think.py
@@ -133,6 +133,28 @@ class TestWrapThinking(unittest.TestCase):
 
         assert full_output == "<think>\nThinking.\n</think>Hello world."
 
+    def test_empty_reasoning_chunks_keep_block_open(self) -> None:
+        chunks = [
+            {"reasoning_content": "A", "content": ""},
+            {"reasoning_content": "", "content": ""},
+            {"reasoning": "B", "content": ""},
+            {"reasoning": "", "content": ""},
+            {"reasoning_content": "", "reasoning": "", "content": ""},
+            {"reasoning_content": "C", "content": ""},
+            {"content": "Answer"},
+        ]
+
+        is_reasoning = False
+        full_output = ""
+        for chunk in chunks:
+            output, is_reasoning = self.llm._wrap_thinking_by_reasoning_content(
+                chunk, is_reasoning
+            )
+            full_output += output
+
+        assert full_output == "<think>\nABC\n</think>Answer"
+        assert is_reasoning is False
+
     def test_reasoning_key_fallback(self) -> None:
         """Use reasoning when reasoning_content is absent."""
         chunks = [

--- a/tests/interfaces/model/test_wrap_think.py
+++ b/tests/interfaces/model/test_wrap_think.py
@@ -133,27 +133,55 @@ class TestWrapThinking(unittest.TestCase):
 
         assert full_output == "<think>\nThinking.\n</think>Hello world."
 
-    def test_empty_reasoning_chunks_keep_block_open(self) -> None:
-        chunks = [
-            {"reasoning_content": "A", "content": ""},
-            {"reasoning_content": "", "content": ""},
-            {"reasoning": "B", "content": ""},
-            {"reasoning": "", "content": ""},
-            {"reasoning_content": "", "reasoning": "", "content": ""},
-            {"reasoning_content": "C", "content": ""},
-            {"content": "Answer"},
-        ]
+    def test_empty_reasoning_closes_block(self) -> None:
+        output, is_reasoning = self.llm._wrap_thinking_by_reasoning_content(
+            {"reasoning_content": "A"},
+            False,
+        )
+        closing, is_reasoning = self.llm._wrap_thinking_by_reasoning_content(
+            {"reasoning_content": ""},
+            is_reasoning,
+        )
 
-        is_reasoning = False
-        full_output = ""
-        for chunk in chunks:
-            output, is_reasoning = self.llm._wrap_thinking_by_reasoning_content(
-                chunk, is_reasoning
-            )
-            full_output += output
-
-        assert full_output == "<think>\nABC\n</think>Answer"
+        assert output + closing == "<think>\nA\n</think>"
         assert is_reasoning is False
+
+    def test_empty_reasoning_closes_on_tool_transition(self) -> None:
+        for transition in (
+            {"tool_calls": [{"id": "call"}]},
+            {"function_call": {"name": "call"}},
+        ):
+            with self.subTest(transition=transition):
+                output, is_reasoning = self.llm._wrap_thinking_by_reasoning_content(
+                    {"reasoning_content": "A"},
+                    False,
+                )
+                closing, is_reasoning = self.llm._wrap_thinking_by_reasoning_content(
+                    {"reasoning_content": "", **transition},
+                    is_reasoning,
+                )
+
+                assert output + closing == "<think>\nA\n</think>"
+                assert is_reasoning is False
+
+    def test_reasoning_and_transition_in_same_chunk(self) -> None:
+        for already_started, opening in ((False, "<think>\n"), (True, "")):
+            for transition, suffix in (
+                ({"content": "Answer"}, "Answer"),
+                ({"tool_calls": [{"id": "call"}]}, ""),
+                ({"function_call": {"name": "call"}}, ""),
+            ):
+                with self.subTest(
+                    already_started=already_started,
+                    transition=transition,
+                ):
+                    output, is_reasoning = self.llm._wrap_thinking_by_reasoning_content(
+                        {"reasoning_content": "A", **transition},
+                        already_started,
+                    )
+
+                    assert output == f"{opening}A\n</think>{suffix}"
+                    assert is_reasoning is False
 
     def test_reasoning_key_fallback(self) -> None:
         """Use reasoning when reasoning_content is absent."""


### PR DESCRIPTION
# Pull Request Checklist

Thank you for your contribution! Before submitting your PR, please make sure you have completed the following checks:

## Compatibility Check

- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [x] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [x] I have checked whether the plugin version is updated in the `README.md`

## Available Checks

- [x] `just build` has passed
- [x] Relevant documentation has been updated (if necessary)

## Summary

Refs #277.
Refs #366.

Explicit empty `reasoning_content` or `reasoning` deltas are now no-ops while an OpenAI-compatible reasoning block is open.
Null or missing reasoning fields and content, tool, or function transitions still close the block.
Reasoning and a real transition in the same delta are also closed without dropping content.

An open block is finalized once on stream exit, before tool and final chunks.
This covers the terminal empty-delta, usage-only, and `[DONE]` sequence reported in [vLLM #38499](https://github.com/vllm-project/vllm/issues/38499) without trusting per-frame `finish_reason` values that can be premature ([OpenWebUI #16377](https://github.com/open-webui/open-webui/issues/16377), [#23921](https://github.com/open-webui/open-webui/issues/23921)).
Non-JSON termination now uses the same single finalization path.

Compatibility: no public API, helper signature, or schema changes.
The guard runs before provider-specific wrapper dispatch, so existing two-argument overrides inherit the stream fix.
Official plugin release and lock validation remain tracked in #366.

## Validation

- `uv run pytest -q tests/interfaces/model/test_wrap_think.py tests/interfaces/model/openai_compatible/test_llm.py` (28 passed, 8 subtests)
- `just check`
- `just test` (162 passed, 1 skipped)
- `just build`