### PR TITLE
fix(file): use tool file app parameters

### DIFF
--- a/src/dify_plugin/invocations/file.py
+++ b/src/dify_plugin/invocations/file.py
@@ -43,8 +43,8 @@ class UploadFileResponse(BaseModel):
 
     def to_app_parameter(self) -> dict:
         return {
-            "upload_file_id": self.id,
-            "transfer_method": "local_file",
+            "tool_file_id": self.id,
+            "transfer_method": "tool_file",
             "type": self.Type.from_mime_type(self.mime_type).value,
         }
 

--- a/tests/invocations/test_file.py
+++ b/tests/invocations/test_file.py
@@ -1,0 +1,17 @@
+from dify_plugin.invocations.file import UploadFileResponse
+
+
+def test_upload_response_converts_to_tool_file_parameter() -> None:
+    response = UploadFileResponse(
+        id="file-id",
+        name="image.png",
+        size=1,
+        extension="png",
+        mime_type="image/png",
+    )
+
+    assert response.to_app_parameter() == {
+        "tool_file_id": "file-id",
+        "transfer_method": "tool_file",
+        "type": "image",
+    }


### PR DESCRIPTION
# Pull Request Checklist

Thank you for your contribution! Before submitting your PR, please make sure you have completed the following checks:

## Compatibility Check

- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [x] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md`
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [x] I have checked whether the plugin version is updated in the `README.md`

## Available Checks

- [x] `just build` has passed
- [x] Relevant documentation has been updated (if necessary)

No documentation or version update is needed for this focused bug fix.

## Summary

Fixes #291.

File uploads return ToolFile IDs, but UploadFileResponse.to_app_parameter() labeled those IDs as local upload files.
The helper now emits the matching tool_file transfer method and tool_file_id field.
A focused test locks the app parameter mapping and MIME-derived file type.

## Compatibility impact

The public method signature is unchanged.
The returned mapping now follows the existing Dify ToolFile protocol instead of producing an invalid local-file mapping.
No manifest, minimum Dify version, or package version change is required.

## Validation

- `uv run pytest tests/invocations/test_file.py -q` (1 passed)
- `just check`
- `just test` (185 passed, 1 skipped)
- `just build`