### PR TITLE
fix(tts): propagate output mime type

### DIFF
--- a/src/dify_plugin/core/plugin_executor.py
+++ b/src/dify_plugin/core/plugin_executor.py
@@ -551,6 +551,10 @@ class PluginExecutor:  # ruff:ignore[too-many-public-methods]
         )
         if isinstance(model_instance, TTSModel):
             with use_current_session(session):
+                mime_type = model_instance.get_tts_model_mime_type(
+                    data.model,
+                    data.credentials,
+                )
                 b = model_instance.invoke(
                     data.model,
                     data.tenant_id,
@@ -559,12 +563,12 @@ class PluginExecutor:  # ruff:ignore[too-many-public-methods]
                     data.voice,
                     data.user_id,
                 )
-                if isinstance(b, bytes | bytearray | memoryview):
-                    yield {"result": binascii.hexlify(b).decode()}
-                    return
-
-                for chunk in b:
-                    yield {"result": binascii.hexlify(chunk).decode()}
+                chunks = (b,) if isinstance(b, bytes | bytearray | memoryview) else b
+                for chunk in chunks:
+                    result = {"result": binascii.hexlify(chunk).decode()}
+                    if mime_type is not None:
+                        result["mime_type"] = mime_type
+                    yield result
         else:
             msg = f"Model `{data.model_type}` not found for provider `{data.provider}`"
             raise TypeError(

--- a/src/dify_plugin/entities/model/tts.py
+++ b/src/dify_plugin/entities/model/tts.py
@@ -20,3 +20,4 @@ class TTSResult(BaseModel):
     """
 
     result: str
+    mime_type: str | None = None

--- a/src/dify_plugin/interfaces/model/tts_model.py
+++ b/src/dify_plugin/interfaces/model/tts_model.py
@@ -11,7 +11,14 @@ from dify_plugin.entities.model import ModelPropertyKey, ModelType
 from dify_plugin.interfaces.model.ai_model import AIModel
 
 logger = logging.getLogger(__name__)
-EMPTY_STRING = ""
+
+_MIME_TYPE_BY_AUDIO_TYPE = {
+    "mp3": "audio/mpeg",
+    "wav": "audio/wav",
+    "ogg": "audio/ogg",
+    "aac": "audio/aac",
+    "mp4": "audio/mp4",
+}
 
 
 class TTSModel(AIModel):
@@ -162,24 +169,22 @@ class TTSModel(AIModel):
         max_length: int = 2000,
         pattern: str = r"[。.!?]",
     ) -> list[str]:
-        match = re.compile(pattern)
-        tx = match.finditer(org_text)
+        if max_length <= 0:
+            msg = "max_length must be greater than 0"
+            raise ValueError(msg)
+
+        sentence_end = re.compile(pattern)
         start = 0
-        result = []
-        one_sentence = ""
-        for i in tx:
-            end = i.regs[0][1]
-            tmp = org_text[start:end]
-            if len(one_sentence + tmp) > max_length:
-                result.append(one_sentence)
-                one_sentence = ""
-            one_sentence += tmp
-            start = end
-        last_sens = org_text[start:]
-        if last_sens:
-            one_sentence += last_sens
-        if one_sentence != EMPTY_STRING:
-            result.append(one_sentence)
+        result: list[str] = []
+        while start < len(org_text):
+            window_end = min(start + max_length, len(org_text))
+            split_at = window_end
+            if window_end < len(org_text):
+                for match in sentence_end.finditer(org_text, start, window_end):
+                    if match.end() > start:
+                        split_at = match.end()
+            result.append(org_text[start:split_at])
+            start = split_at
         return result
 
     # Streaming behavior can be improved independently of filename generation.
@@ -195,6 +200,16 @@ class TTSModel(AIModel):
     ############################################################
     #                 For executor use only                    #
     ############################################################
+
+    def get_tts_model_mime_type(
+        self,
+        model: str,
+        credentials: dict,
+    ) -> str | None:
+        """Get the standard MIME type declared by the model schema."""
+        return _MIME_TYPE_BY_AUDIO_TYPE.get(
+            self._get_model_audio_type(model, credentials)
+        )
 
     def invoke(
         self,

--- a/tests/core/test_invoke_tts.py
+++ b/tests/core/test_invoke_tts.py
@@ -1,0 +1,53 @@
+from collections.abc import Generator
+from unittest.mock import MagicMock
+
+from dify_plugin.core.entities.plugin.request import ModelInvokeTTSRequest
+from dify_plugin.core.plugin_executor import PluginExecutor
+from dify_plugin.core.runtime import Session
+from dify_plugin.entities.model import ModelType
+from dify_plugin.interfaces.model.tts_model import TTSModel
+
+
+def _invoke_tts(
+    audio: bytes | Generator[bytes, None, None],
+    mime_type: str | None,
+) -> list[dict[str, str]]:
+    model = MagicMock(spec=TTSModel)
+    model.invoke.return_value = audio
+    model.get_tts_model_mime_type.return_value = mime_type
+    registration = MagicMock()
+    registration.get_model_instance.return_value = model
+    executor = PluginExecutor(config=MagicMock(), registration=registration)
+    request = ModelInvokeTTSRequest(
+        user_id="user",
+        provider="provider",
+        model_type=ModelType.TTS,
+        model="model",
+        credentials={},
+        content_text="text",
+        voice="voice",
+        tenant_id="tenant",
+    )
+
+    result = list(executor.invoke_tts(Session.empty_session(), request))
+    model.get_tts_model_mime_type.assert_called_once_with("model", {})
+    return result
+
+
+def test_invoke_tts_includes_mime_type_for_bytes() -> None:
+    assert _invoke_tts(b"\x00\x01", "audio/wav") == [
+        {"result": "0001", "mime_type": "audio/wav"}
+    ]
+
+
+def test_invoke_tts_includes_mime_type_for_each_stream_chunk() -> None:
+    audio = (chunk for chunk in (b"\x00", b"\x01"))
+
+    assert _invoke_tts(audio, "audio/mpeg") == [
+        {"result": "00", "mime_type": "audio/mpeg"},
+        {"result": "01", "mime_type": "audio/mpeg"},
+    ]
+
+
+def test_invoke_tts_omits_missing_mime_type() -> None:
+    assert _invoke_tts(b"\x00", None) == [{"result": "00"}]

--- a/tests/interfaces/model/test_tts_model.py
+++ b/tests/interfaces/model/test_tts_model.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from dify_plugin.entities.model.tts import TTSResult
+from dify_plugin.interfaces.model.tts_model import TTSModel
+
+
+@pytest.mark.parametrize(
+    ("audio_type", "expected"),
+    [
+        ("mp3", "audio/mpeg"),
+        ("wav", "audio/wav"),
+        ("ogg", "audio/ogg"),
+        ("aac", "audio/aac"),
+        ("mp4", "audio/mp4"),
+        ("unknown", None),
+        (None, None),
+    ],
+)
+def test_get_tts_model_mime_type(
+    audio_type: str | None,
+    expected: str | None,
+) -> None:
+    model = MagicMock(spec=TTSModel)
+    model._get_model_audio_type.return_value = audio_type
+
+    assert TTSModel.get_tts_model_mime_type(model, "model", {}) == expected
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected"),
+    [
+        ({"result": "00"}, {"result": "00"}),
+        (
+            {"result": "00", "mime_type": "audio/wav"},
+            {"result": "00", "mime_type": "audio/wav"},
+        ),
+    ],
+)
+def test_tts_result_mime_type_is_optional(
+    payload: dict[str, str],
+    expected: dict[str, str],
+) -> None:
+    result = TTSResult.model_validate(payload)
+
+    assert result.model_dump(exclude_none=True) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "max_length", "expected"),
+    [
+        ("", 4, []),
+        ("abcd", 4, ["abcd"]),
+        ("abcdefghij", 4, ["abcd", "efgh", "ij"]),
+        ("abcd.", 3, ["abc", "d."]),
+        ("Hi.xxxxxx", 5, ["Hi.", "xxxxx", "x"]),
+        ("One.Two?Three!", 8, ["One.Two?", "Three!"]),
+    ],
+)
+def test_split_text_into_sentences(
+    text: str,
+    max_length: int,
+    expected: list[str],
+) -> None:
+    chunks = TTSModel._split_text_into_sentences(text, max_length)
+
+    assert chunks == expected
+    assert "".join(chunks) == text
+    assert all(chunks)
+    assert all(len(chunk) <= max_length for chunk in chunks)
+
+
+@pytest.mark.parametrize("max_length", [0, -1])
+def test_split_text_into_sentences_rejects_non_positive_length(
+    max_length: int,
+) -> None:
+    with pytest.raises(ValueError, match="max_length must be greater than 0"):
+        TTSModel._split_text_into_sentences("text", max_length)


### PR DESCRIPTION
## Summary

- Propagate TTS MIME types declared by model schemas for MP3, WAV, OGG, AAC, and MP4.
- Preserve legacy TTS result payloads when MIME is unavailable.
- Split oversized TTS text without emitting empty or over-limit chunks.

## Testing

- `uv run pytest tests/interfaces/model/test_tts_model.py tests/core/test_invoke_tts.py`
- `just check`
- `just test`

## Related issue

- Refs langgenius/dify#35880.
- Tracks EE-1836.