### PR TITLE
feat: support reset_on_change for tool parameters

### DIFF
--- a/src/dify_plugin/entities/tool.py
+++ b/src/dify_plugin/entities/tool.py
@@ -154,6 +154,13 @@ class ToolParameter(BaseModel):
         default_factory=list,
         description="The conditions that control whether the parameter is shown",
     )
+    reset_on_change: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Sibling parameter names that reset this parameter to its default or "
+            "empty value when changed"
+        ),
+    )
 
     @model_validator(mode="after")
     def validate_multiple(self) -> "ToolParameter":

--- a/tests/entities/test_tool.py
+++ b/tests/entities/test_tool.py
@@ -84,6 +84,25 @@ def test_tool_parameter_preserves_show_on_conditions() -> None:
     assert defaulted.options[0].show_on == []
 
 
+def test_tool_parameter_preserves_reset_on_change() -> None:
+    base = {
+        "name": "region",
+        "label": {"en_US": "Region"},
+        "human_description": {"en_US": "Region to use"},
+        "type": "dynamic-select",
+        "form": "form",
+    }
+    parameter = ToolParameter.model_validate(base | {"reset_on_change": ["country"]})
+
+    assert parameter.reset_on_change == ["country"]
+    assert parameter.model_dump(mode="json")["reset_on_change"] == ["country"]
+    assert ToolParameter.model_validate(parameter.model_dump()) == parameter
+
+    defaulted = ToolParameter.model_validate(base)
+    assert defaulted.reset_on_change == []
+    assert defaulted.model_dump(mode="json")["reset_on_change"] == []
+
+
 def test_tool_selector_converts_date_parameters_to_prompt_schema() -> None:
     selector = ToolSelector.model_validate({
         "provider_id": "calendar",


### PR DESCRIPTION
Fixes langgenius/dify#40180

## Summary

This PR adds `reset_on_change` support to the Python SDK's `ToolParameter` model.

Plugin developers can declare sibling parameters that should reset the current parameter to its default or empty value when changed:

```yaml
reset_on_change:
  - country
  - region
```

The field defaults to an empty list, preserving the behavior of existing plugin declarations.

Unit tests have been added to verify:

- Parsing `reset_on_change` from a tool parameter declaration
- JSON serialization
- Model dump and validation round trips
- Default empty-list behavior when the field is omitted

## Compatibility Impact

This is an additive and backward-compatible change. Existing plugin declarations do not need to define `reset_on_change` and will continue to work as before.

Plugins using `reset_on_change` require compatible Dify platform and plugin daemon versions. This change does not introduce a breaking schema change, so no plugin declaration version or README version update is required.

# Pull Request Checklist

Thank you for your contribution! Before submitting your PR, please make sure you have completed the following checks:

## Compatibility Check

- [x] I have checked whether this change affects the **backward compatibility** of the plugin declared in `README.md`
- [x] I have checked whether this change affects the **forward compatibility** of the plugin declared in `README.md`
- [x] If this change introduces a breaking change, I have discussed it with the project maintainer and specified the release version in the `README.md` (Not applicable: this is not a breaking change)
- [x] I have described the compatibility impact and the corresponding version number in the PR description
- [x] I have checked whether the plugin version is updated in the `README.md` (No version update is required)

## Available Checks

- [ ] `just build` has passed
- [x] Relevant documentation has been updated (Not applicable: no documentation update is required)
